### PR TITLE
pass host_name as byte_cursor

### DIFF
--- a/include/aws/http/connection.h
+++ b/include/aws/http/connection.h
@@ -62,7 +62,7 @@ struct aws_http_client_connection_options {
      * Required.
      * aws_http_client_connect() makes a copy.
      */
-    const char *host_name;
+    struct aws_byte_cursor host_name;
 
     /**
      * Required.

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -223,7 +223,7 @@ static int s_tester_init(struct tester *tester, const struct tester_options *opt
     struct aws_http_client_connection_options client_options = AWS_HTTP_CLIENT_CONNECTION_OPTIONS_INIT;
     client_options.allocator = tester->alloc;
     client_options.bootstrap = tester->client_bootstrap;
-    client_options.host_name = endpoint.address;
+    client_options.host_name = aws_byte_cursor_from_c_str(endpoint.address);
     client_options.port = endpoint.port;
     client_options.socket_options = &socket_options;
     client_options.user_data = tester;


### PR DESCRIPTION
I went in intending to use `aws_uri`, and it turns out we never want the full URI, just specific pieces at specific times.

Made a super mild change while I was in there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
