### PR TITLE
Fallback for ALPN is now http 1.1. We'll likely change this up a bit …

### DIFF
--- a/source/connection.c
+++ b/source/connection.c
@@ -94,13 +94,12 @@ static struct aws_http_connection *s_connection_new(
             } else if (aws_string_eq_byte_buf(s_alpn_protocol_http_2, &protocol)) {
                 version = AWS_HTTP_VERSION_2;
             } else {
-                AWS_LOGF_ERROR(
+                AWS_LOGF_WARN(
                     AWS_LS_HTTP_CONNECTION,
-                    "static: Unrecognized ALPN protocol '" PRInSTR "'.",
+                    "static: Unrecognized ALPN protocol '" PRInSTR "'. Assuming Http/1.1",
                     AWS_BYTE_BUF_PRI(protocol));
 
-                aws_raise_error(AWS_ERROR_HTTP_UNSUPPORTED_PROTOCOL);
-                goto error;
+                version = AWS_HTTP_VERSION_1_1;
             }
         }
     }

--- a/source/connection.c
+++ b/source/connection.c
@@ -94,10 +94,9 @@ static struct aws_http_connection *s_connection_new(
             } else if (aws_string_eq_byte_buf(s_alpn_protocol_http_2, &protocol)) {
                 version = AWS_HTTP_VERSION_2;
             } else {
-                AWS_LOGF_WARN(
-                    AWS_LS_HTTP_CONNECTION,
-                    "static: Unrecognized ALPN protocol '" PRInSTR "'. Assuming Http/1.1",
-                    AWS_BYTE_BUF_PRI(protocol));
+                AWS_LOGF_WARN(AWS_LS_HTTP_CONNECTION, "static: Unrecognized ALPN protocol. Assuming HTTP/1.1");
+                AWS_LOGF_DEBUG(
+                    AWS_LS_HTTP_CONNECTION, "static: Unrecognized ALPN protocol " PRInSTR, AWS_BYTE_BUF_PRI(protocol));
 
                 version = AWS_HTTP_VERSION_1_1;
             }


### PR DESCRIPTION
…when we add h2 support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
