### PR TITLE
Compile fix

### DIFF
--- a/tests/test_websocket_encoder.c
+++ b/tests/test_websocket_encoder.c
@@ -155,7 +155,7 @@ ENCODER_TEST_CASE(websocket_encoder_rsv) {
             0x89, // fin | rsv1 | rsv2 | rsv3 | 4bit opcode
             0x00, // mask | 7bit payload len
         };
-        expected_output[0] |= (uint8_t)(1 << (6 - rsv));
+        expected_output[0] = (uint8_t)(expected_output[0] | (1 << (6 - rsv)));
 
         tester.out_buf.len = 0; /* reset output buffer */
         ASSERT_SUCCESS(aws_websocket_encoder_start_frame(&tester.encoder, &input_frame));


### PR DESCRIPTION
Failing build due to '|=' implicitly converting to int.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
