### PR TITLE
More HTTP1.1 refactors

### DIFF
--- a/include/aws/http/private/h1_decoder.h
+++ b/include/aws/http/private/h1_decoder.h
@@ -36,7 +36,7 @@ AWS_EXTERN_C_BEGIN
 
 AWS_HTTP_API struct aws_h1_decoder *aws_h1_decoder_new(struct aws_h1_decoder_params *params);
 AWS_HTTP_API void aws_h1_decoder_destroy(struct aws_h1_decoder *decoder);
-AWS_HTTP_API int aws_h1_decode(struct aws_h1_decoder *decoder, const void *data, size_t data_bytes, size_t *bytes_read);
+AWS_HTTP_API int aws_h1_decode(struct aws_h1_decoder *decoder, struct aws_byte_cursor *data);
 
 AWS_HTTP_API void aws_h1_decoder_set_logging_id(struct aws_h1_decoder *decoder, void *id);
 

--- a/include/aws/http/private/h1_decoder.h
+++ b/include/aws/http/private/h1_decoder.h
@@ -19,42 +19,6 @@
 #include <aws/http/private/http_impl.h>
 
 /**
- * Called from `aws_h1_decode` when an http header has been received.
- * All pointers are strictly *read only*; any data that needs to persist must be copied out into user-owned memory.
- */
-typedef int(aws_h1_decoder_on_header_fn)(const struct aws_http_decoded_header *header, void *user_data);
-
-/**
- * Called from `aws_h1_decode` when a portion of the http body has been received.
- * `finished` is true if this is the last section of the http body, and false if more body data is yet to be received.
- * All pointers are strictly *read only*; any data that needs to persist must be copied out into user-owned memory.
- */
-typedef int(aws_h1_decoder_on_body_fn)(const struct aws_byte_cursor *data, bool finished, void *user_data);
-
-typedef int(aws_h1_decoder_on_request_fn)(
-    enum aws_http_method method_enum,
-    const struct aws_byte_cursor *method_str,
-    const struct aws_byte_cursor *uri,
-    void *user_data);
-
-typedef int(aws_h1_decoder_on_response_fn)(int status_code, void *user_data);
-
-typedef int(aws_h1_decoder_done_fn)(void *user_data);
-
-struct aws_h1_decoder_vtable {
-    aws_h1_decoder_on_header_fn *on_header;
-    aws_h1_decoder_on_body_fn *on_body;
-
-    /* Only needed for requests, can be NULL for responses. */
-    aws_h1_decoder_on_request_fn *on_request;
-
-    /* Only needed for responses, can be NULL for requests. */
-    aws_h1_decoder_on_response_fn *on_response;
-
-    aws_h1_decoder_done_fn *on_done;
-};
-
-/**
  * Structure used to initialize an `aws_h1_decoder`.
  */
 struct aws_h1_decoder_params {
@@ -63,7 +27,7 @@ struct aws_h1_decoder_params {
     /* Set false if decoding responses */
     bool is_decoding_requests;
     void *user_data;
-    struct aws_h1_decoder_vtable vtable;
+    struct aws_http_decoder_vtable vtable;
 };
 
 struct aws_h1_decoder;

--- a/include/aws/http/private/http_impl.h
+++ b/include/aws/http/private/http_impl.h
@@ -63,6 +63,42 @@ struct aws_http_decoded_header {
     struct aws_byte_cursor data;
 };
 
+/**
+ * Called from `aws_h*_decode` when an http header has been received.
+ * All pointers are strictly *read only*; any data that needs to persist must be copied out into user-owned memory.
+ */
+typedef int(aws_http_decoder_on_header_fn)(const struct aws_http_decoded_header *header, void *user_data);
+
+/**
+ * Called from `aws_h*_decode` when a portion of the http body has been received.
+ * `finished` is true if this is the last section of the http body, and false if more body data is yet to be received.
+ * All pointers are strictly *read only*; any data that needs to persist must be copied out into user-owned memory.
+ */
+typedef int(aws_http_decoder_on_body_fn)(const struct aws_byte_cursor *data, bool finished, void *user_data);
+
+typedef int(aws_http_decoder_on_request_fn)(
+    enum aws_http_method method_enum,
+    const struct aws_byte_cursor *method_str,
+    const struct aws_byte_cursor *uri,
+    void *user_data);
+
+typedef int(aws_http_decoder_on_response_fn)(int status_code, void *user_data);
+
+typedef int(aws_http_decoder_done_fn)(void *user_data);
+
+struct aws_http_decoder_vtable {
+    aws_http_decoder_on_header_fn *on_header;
+    aws_http_decoder_on_body_fn *on_body;
+
+    /* Only needed for requests, can be NULL for responses. */
+    aws_http_decoder_on_request_fn *on_request;
+
+    /* Only needed for responses, can be NULL for requests. */
+    aws_http_decoder_on_response_fn *on_response;
+
+    aws_http_decoder_done_fn *on_done;
+};
+
 AWS_EXTERN_C_BEGIN
 
 AWS_HTTP_API void aws_http_fatal_assert_library_initialized(void);

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -95,7 +95,7 @@ static const struct aws_http_stream_vtable s_stream_vtable = {
     .update_window = s_stream_update_window,
 };
 
-static const struct aws_h1_decoder_vtable s_decoder_vtable = {
+static const struct aws_http_decoder_vtable s_h1_decoder_vtable = {
     .on_request = s_decoder_on_request,
     .on_response = s_decoder_on_response,
     .on_header = s_decoder_on_header,
@@ -1201,7 +1201,7 @@ static struct h1_connection *s_connection_new(struct aws_allocator *alloc) {
         .alloc = alloc,
         .is_decoding_requests = connection->base.server_data != NULL,
         .user_data = connection,
-        .vtable = s_decoder_vtable,
+        .vtable = s_h1_decoder_vtable,
         .scratch_space_initial_size = DECODER_INITIAL_SCRATCH_SIZE,
     };
     connection->thread_data.incoming_stream_decoder = aws_h1_decoder_new(&options);

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -22,8 +22,6 @@
 #include <aws/http/private/request_response_impl.h>
 #include <aws/io/logging.h>
 
-#include <stdio.h>
-
 #if _MSC_VER
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
@@ -1316,9 +1314,7 @@ static int s_handler_process_read_message(
         aws_h1_decoder_set_logging_id(
             connection->thread_data.incoming_stream_decoder, connection->thread_data.incoming_stream);
 
-        size_t decoded_len = 0;
-        err = aws_h1_decode(
-            connection->thread_data.incoming_stream_decoder, message_cursor.ptr, message_cursor.len, &decoded_len);
+        err = aws_h1_decode(connection->thread_data.incoming_stream_decoder, &message_cursor);
         if (err) {
             AWS_LOGF_ERROR(
                 AWS_LS_HTTP_CONNECTION,
@@ -1329,9 +1325,6 @@ static int s_handler_process_read_message(
 
             goto error;
         }
-
-        AWS_FATAL_ASSERT(decoded_len > 0);
-        aws_byte_cursor_advance(&message_cursor, decoded_len);
     }
 
     AWS_LOGF_TRACE(AWS_LS_HTTP_CONNECTION, "id=%p: Done processing message.", (void *)&connection->base);


### PR DESCRIPTION
* Move the decoder vtable from h1_decoder.h to http_impl.h
* Refactor h1 decoder to operate on byte_cursors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
