### PR TITLE
Fix for mem-release crash on h1 decode failure

### DIFF
--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -1294,7 +1294,7 @@ static int s_handler_process_read_message(
                 (void *)&connection->base);
 
             aws_raise_error(AWS_ERROR_HTTP_CONNECTION_CLOSED);
-            goto error;
+            goto shutdown;
         }
 
         if (!connection->thread_data.incoming_stream) {
@@ -1307,7 +1307,7 @@ static int s_handler_process_read_message(
                 (void *)&connection->base);
 
             aws_raise_error(AWS_ERROR_INVALID_STATE);
-            goto error;
+            goto shutdown;
         }
 
         /* Decoder will invoke the internal s_decoder_X callbacks, which in turn invoke user callbacks */
@@ -1323,7 +1323,7 @@ static int s_handler_process_read_message(
                 aws_last_error(),
                 aws_error_name(aws_last_error()));
 
-            goto error;
+            goto shutdown;
         }
     }
 
@@ -1339,16 +1339,17 @@ static int s_handler_process_read_message(
                 aws_last_error(),
                 aws_error_name(aws_last_error()));
 
-            goto error;
+            goto shutdown;
         }
     }
 
     aws_mem_release(message->allocator, message);
     return AWS_OP_SUCCESS;
-error:
+
+shutdown:
     aws_mem_release(message->allocator, message);
     s_shutdown_connection(connection, aws_last_error());
-    return AWS_OP_ERR;
+    return AWS_OP_SUCCESS;
 }
 
 static int s_handler_process_write_message(


### PR DESCRIPTION
return SUCCESS on process read failures so that sender does not try and clean up message


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
