### PR TITLE
Fix websocket shutdown callback timing.

### DIFF
--- a/include/aws/http/private/websocket_impl.h
+++ b/include/aws/http/private/websocket_impl.h
@@ -65,7 +65,6 @@ struct aws_websocket_handler_options {
     size_t initial_window_size;
 
     void *user_data;
-    aws_websocket_on_connection_shutdown_fn *on_connection_shutdown;
     aws_websocket_on_incoming_frame_begin_fn *on_incoming_frame_begin;
     aws_websocket_on_incoming_frame_payload_fn *on_incoming_frame_payload;
     aws_websocket_on_incoming_frame_complete_fn *on_incoming_frame_complete;


### PR DESCRIPTION
This is similar to https://github.com/awslabs/aws-c-http/pull/72

Websocket's `on_connection_shutdown` callback shouldn't fire during the handler shutdown, it should fire during the channel's shutdown.

This change clarified some questions I had about lifetime/ownership (hence the deleted TODOs and modified API comments)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
