### PR TITLE
mutable aws_http_request object

### DIFF
--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -43,16 +43,8 @@ struct aws_http_header {
  *
  * The request keeps internal copies of its trivial strings (method, path, headers)
  * but does NOT take ownership of its body stream.
- *
- * Do not access the members of this struct directly, use the aws_http_request_XYZ() functions.
  */
-struct aws_http_request {
-    struct aws_allocator *allocator;
-    struct aws_string *method;
-    struct aws_string *path;
-    struct aws_array_list headers;
-    struct aws_input_stream *body_stream;
-};
+struct aws_http_request;
 
 /**
  * A function that may modify the request before it is sent.
@@ -206,26 +198,24 @@ struct aws_http_response_options {
 AWS_EXTERN_C_BEGIN
 
 /**
- * Initialize the request.
- * The request is blank, and all data (method, path, etc) must be set individually.
+ * Create a new request.
+ * The request is blank, all properties (method, path, etc) must be set individually.
  */
 AWS_HTTP_API
-int aws_http_request_init(struct aws_http_request *request, struct aws_allocator *allocator);
+struct aws_http_request *aws_http_request_new(struct aws_allocator *allocator);
 
 /**
- * Clean up the request.
- * This function is idempotent, it has no effect if called on a request that has
- * failed initialization or been zeroed out.
+ * Destroy the the request.
  */
 AWS_HTTP_API
-void aws_http_request_clean_up(struct aws_http_request *request);
+void aws_http_request_destroy(struct aws_http_request *request);
 
 /**
  * Get the method.
- * If no method is set, an empty byte cursor is returned.
+ * If no method is set, AWS_ERROR_HTTP_DATA_NOT_AVAILABLE is raised.
  */
 AWS_HTTP_API
-struct aws_byte_cursor aws_http_request_get_method(const struct aws_http_request *request);
+int aws_http_request_get_method(const struct aws_http_request *request, struct aws_byte_cursor *out_method);
 
 /**
  * Set the method.
@@ -236,10 +226,10 @@ int aws_http_request_set_method(struct aws_http_request *request, struct aws_byt
 
 /**
  * Get the path (and query) value.
- * If no path is set, an empty byte cursor is returned.
+ * If no path is set, AWS_ERROR_HTTP_DATA_NOT_AVAILABLE is raised.
  */
 AWS_HTTP_API
-struct aws_byte_cursor aws_http_request_get_path(const struct aws_http_request *request);
+int aws_http_request_get_path(const struct aws_http_request *request, struct aws_byte_cursor *out_path);
 
 /**
  * Set the path (and-query) value.
@@ -273,13 +263,16 @@ size_t aws_http_request_get_header_count(const struct aws_http_request *request)
 
 /**
  * Get the header at the specified index.
- * If the index is invalid, a header is returned with a blank name and value,
- * a language-binding should throw an exception instead.
+ * This function cannot fail if a valid index is provided.
+ * Otherwise, AWS_ERROR_INVALID_INDEX will be raised.
  *
  * The underlying strings are stored within the request.
  */
 AWS_HTTP_API
-struct aws_http_header aws_http_request_get_header(const struct aws_http_request *request, size_t index);
+int aws_http_request_get_header(
+    const struct aws_http_request *request,
+    struct aws_http_header *out_header,
+    size_t index);
 
 /**
  * Add a header to the end of the array.

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -300,11 +300,11 @@ int aws_http_request_set_header(struct aws_http_request *request, struct aws_htt
  * Remove the header at the specified index.
  * Headers after this index are all shifted back one position.
  *
- * Nothing happens if an invalid index is specified,
- * a language binding might choose to throw an exception instead.
+ * This function cannot fail if a valid index is provided.
+ * Otherwise, AWS_ERROR_INVALID_INDEX will be raised.
  */
 AWS_HTTP_API
-void aws_http_request_erase_header(struct aws_http_request *request, size_t index);
+int aws_http_request_erase_header(struct aws_http_request *request, size_t index);
 
 /**
  * Create a stream, with a client connection sending a request.

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -29,6 +29,14 @@ enum {
     AWS_HTTP_REQUEST_NUM_RESERVED_HEADERS = 16,
 };
 
+struct aws_http_request {
+    struct aws_allocator *allocator;
+    struct aws_string *method;
+    struct aws_string *path;
+    struct aws_array_list headers;
+    struct aws_input_stream *body_stream;
+};
+
 /* Type stored within the aws_http_request.headers array_list.
  * Different from aws_http_header in that it owns its string memory. */
 struct aws_http_header_impl {
@@ -59,16 +67,6 @@ static int s_set_string_from_cursor(
 
     *dst = new_str;
     return AWS_OP_SUCCESS;
-}
-
-static struct aws_byte_cursor s_get_cursor_from_string(const struct aws_string *str) {
-    AWS_PRECONDITION(!str || aws_string_is_valid(str));
-
-    if (str) {
-        return aws_byte_cursor_from_string(str);
-    }
-
-    return aws_byte_cursor_from_array(NULL, 0);
 }
 
 static void s_header_impl_clean_up(struct aws_http_header_impl *header_impl) {
@@ -105,11 +103,13 @@ error:
     return AWS_OP_ERR;
 }
 
-int aws_http_request_init(struct aws_http_request *request, struct aws_allocator *allocator) {
-    AWS_PRECONDITION(request);
+struct aws_http_request *aws_http_request_new(struct aws_allocator *allocator) {
     AWS_PRECONDITION(allocator);
+    struct aws_http_request *request = aws_mem_calloc(allocator, 1, sizeof(struct aws_http_request));
+    if (!request) {
+        goto error;
+    }
 
-    AWS_ZERO_STRUCT(*request);
     request->allocator = allocator;
 
     int err = aws_array_list_init_dynamic(
@@ -118,14 +118,17 @@ int aws_http_request_init(struct aws_http_request *request, struct aws_allocator
         goto error;
     }
 
-    return AWS_OP_SUCCESS;
+    return request;
 error:
-    aws_http_request_clean_up(request);
-    return AWS_OP_ERR;
+    aws_http_request_destroy(request);
+    return NULL;
 }
 
-void aws_http_request_clean_up(struct aws_http_request *request) {
-    AWS_PRECONDITION(request);
+void aws_http_request_destroy(struct aws_http_request *request) {
+    AWS_PRECONDITION(!request || request->allocator);
+    if (!request) {
+        return;
+    }
 
     aws_string_destroy(request->method);
     aws_string_destroy(request->path);
@@ -140,7 +143,7 @@ void aws_http_request_clean_up(struct aws_http_request *request) {
 
     aws_array_list_clean_up(&request->headers);
 
-    AWS_ZERO_STRUCT(*request);
+    aws_mem_release(request->allocator, request);
 }
 
 int aws_http_request_set_method(struct aws_http_request *request, struct aws_byte_cursor method) {
@@ -150,10 +153,17 @@ int aws_http_request_set_method(struct aws_http_request *request, struct aws_byt
     return s_set_string_from_cursor(&request->method, method, request->allocator);
 }
 
-struct aws_byte_cursor aws_http_request_get_method(const struct aws_http_request *request) {
+int aws_http_request_get_method(const struct aws_http_request *request, struct aws_byte_cursor *out_method) {
     AWS_PRECONDITION(request);
+    AWS_PRECONDITION(out_method);
 
-    return s_get_cursor_from_string(request->method);
+    if (request->method) {
+        *out_method = aws_byte_cursor_from_string(request->method);
+        return AWS_OP_SUCCESS;
+    }
+
+    AWS_ZERO_STRUCT(*out_method);
+    return aws_raise_error(AWS_ERROR_HTTP_DATA_NOT_AVAILABLE);
 }
 
 int aws_http_request_set_path(struct aws_http_request *request, struct aws_byte_cursor path) {
@@ -163,9 +173,17 @@ int aws_http_request_set_path(struct aws_http_request *request, struct aws_byte_
     return s_set_string_from_cursor(&request->path, path, request->allocator);
 }
 
-struct aws_byte_cursor aws_http_request_get_path(const struct aws_http_request *request) {
+int aws_http_request_get_path(const struct aws_http_request *request, struct aws_byte_cursor *out_path) {
     AWS_PRECONDITION(request);
-    return s_get_cursor_from_string(request->path);
+    AWS_PRECONDITION(out_path);
+
+    if (request->path) {
+        *out_path = aws_byte_cursor_from_string(request->path);
+        return AWS_OP_SUCCESS;
+    }
+
+    AWS_ZERO_STRUCT(*out_path);
+    return aws_raise_error(AWS_ERROR_HTTP_DATA_NOT_AVAILABLE);
 }
 
 void aws_http_request_set_body_stream(struct aws_http_request *request, struct aws_input_stream *body_stream) {
@@ -176,14 +194,6 @@ void aws_http_request_set_body_stream(struct aws_http_request *request, struct a
 struct aws_input_stream *aws_http_request_get_body_stream(const struct aws_http_request *request) {
     AWS_PRECONDITION(request);
     return request->body_stream;
-}
-
-struct aws_http_header s_get_header_view_from_impl(struct aws_http_header_impl *impl) {
-    struct aws_http_header view = {
-        .name = s_get_cursor_from_string(impl->name),
-        .value = s_get_cursor_from_string(impl->value),
-    };
-    return view;
 }
 
 int aws_http_request_add_header(struct aws_http_request *request, struct aws_http_header header) {
@@ -258,20 +268,29 @@ size_t aws_http_request_get_header_count(const struct aws_http_request *request)
     return aws_array_list_length(&request->headers);
 }
 
-struct aws_http_header aws_http_request_get_header(const struct aws_http_request *request, size_t index) {
-    AWS_PRECONDITION(request);
+int aws_http_request_get_header(
+    const struct aws_http_request *request,
+    struct aws_http_header *out_header,
+    size_t index) {
 
-    struct aws_http_header header_view;
-    AWS_ZERO_STRUCT(header_view);
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(out_header);
+
+    AWS_ZERO_STRUCT(*out_header);
 
     struct aws_http_header_impl *header_impl;
     int err = aws_array_list_get_at_ptr(&request->headers, (void **)&header_impl, index);
-    if (!err) {
-        header_view.name = s_get_cursor_from_string(header_impl->name);
-        header_view.value = s_get_cursor_from_string(header_impl->value);
+    if (err) {
+        return AWS_OP_ERR;
     }
 
-    return header_view;
+    if (header_impl->name) {
+        out_header->name = aws_byte_cursor_from_string(header_impl->name);
+    }
+    if (header_impl->value) {
+        out_header->value = aws_byte_cursor_from_string(header_impl->value);
+    }
+    return AWS_OP_SUCCESS;
 }
 
 struct aws_http_stream *aws_http_stream_new_client_request(const struct aws_http_request_options *options) {

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -134,8 +134,8 @@ void aws_http_request_destroy(struct aws_http_request *request) {
     aws_string_destroy(request->path);
 
     const size_t length = aws_array_list_length(&request->headers);
+    struct aws_http_header_impl *header_impl = NULL;
     for (size_t i = 0; i < length; ++i) {
-        struct aws_http_header_impl *header_impl;
         aws_array_list_get_at_ptr(&request->headers, (void **)&header_impl, i);
         AWS_ASSERT(header_impl);
         s_header_impl_clean_up(header_impl);

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -25,11 +25,11 @@
 #endif
 
 enum {
-    /* Initial capacity for the aws_http_request.headers array-list. */
+    /* Initial capacity for the aws_http_request.headers array_list. */
     AWS_HTTP_REQUEST_NUM_RESERVED_HEADERS = 16,
 };
 
-/* Type stored within the aws_http_request.headers array-list.
+/* Type stored within the aws_http_request.headers array_list.
  * Different from aws_http_header in that it owns its string memory. */
 struct aws_http_header_impl {
     struct aws_string *name;

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -15,8 +15,259 @@
 
 #include <aws/http/private/request_response_impl.h>
 
+#include <aws/common/array_list.h>
+#include <aws/common/string.h>
 #include <aws/http/private/connection_impl.h>
 #include <aws/io/logging.h>
+
+#if _MSC_VER
+#    pragma warning(disable : 4204) /* non-constant aggregate initializer */
+#endif
+
+enum {
+    /* Initial capacity for the aws_http_request.headers array-list*/
+    AWS_HTTP_REQUEST_NUM_RESERVED_HEADERS = 16,
+};
+
+/* Type stored within the aws_http_request.headers array-list.
+ * Different from aws_http_header in that it owns its string memory. */
+struct aws_http_header_impl {
+    struct aws_string *name;
+    struct aws_string *value;
+};
+
+static int s_set_string_from_cursor(
+    struct aws_string **dst,
+    struct aws_byte_cursor cursor,
+    struct aws_allocator *alloc) {
+
+    /* If the cursor is empty, set dst to NULL */
+    struct aws_string *new_str;
+    if (cursor.len) {
+        new_str = aws_string_new_from_array(alloc, cursor.ptr, cursor.len);
+        if (!new_str) {
+            return AWS_OP_ERR;
+        }
+    } else {
+        new_str = NULL;
+    }
+
+    /* Replace existing value */
+    aws_string_destroy(*dst);
+
+    *dst = new_str;
+    return AWS_OP_SUCCESS;
+}
+
+static struct aws_byte_cursor s_get_cursor_from_string(const struct aws_string *str) {
+    AWS_PRECONDITION(!str || aws_string_is_valid(str));
+
+    if (str) {
+        return aws_byte_cursor_from_string(str);
+    }
+
+    return aws_byte_cursor_from_array(NULL, 0);
+}
+
+static void s_header_impl_clean_up(struct aws_http_header_impl *header_impl) {
+    aws_string_destroy(header_impl->name);
+    aws_string_destroy(header_impl->value);
+    AWS_ZERO_STRUCT(*header_impl);
+}
+
+static int s_header_impl_init(
+    struct aws_http_header_impl *header_impl,
+    const struct aws_http_header *header_view,
+    struct aws_allocator *alloc) {
+
+    AWS_ZERO_STRUCT(*header_impl);
+
+    int err = s_set_string_from_cursor(&header_impl->name, header_view->name, alloc);
+    if (err) {
+        goto error;
+    }
+
+    err = s_set_string_from_cursor(&header_impl->value, header_view->value, alloc);
+    if (err) {
+        goto error;
+    }
+
+    return AWS_OP_SUCCESS;
+
+error:
+    s_header_impl_clean_up(header_impl);
+    return AWS_OP_ERR;
+}
+
+int aws_http_request_init(struct aws_http_request *request, struct aws_allocator *allocator) {
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(allocator);
+
+    AWS_ZERO_STRUCT(*request);
+    request->allocator = allocator;
+
+    int err = aws_array_list_init_dynamic(
+        &request->headers, allocator, AWS_HTTP_REQUEST_NUM_RESERVED_HEADERS, sizeof(struct aws_http_header_impl));
+    if (err) {
+        goto error;
+    }
+
+    return AWS_OP_SUCCESS;
+error:
+    aws_http_request_clean_up(request);
+    return AWS_OP_ERR;
+}
+
+void aws_http_request_clean_up(struct aws_http_request *request) {
+    AWS_PRECONDITION(request);
+
+    aws_string_destroy(request->method);
+    aws_string_destroy(request->path);
+
+    /* Clean up headers in array */
+    size_t len = aws_array_list_length(&request->headers);
+    if (len > 0) {
+        struct aws_http_header_impl *header_impl;
+        aws_array_list_get_at_ptr(&request->headers, (void **)&header_impl, 0);
+
+        struct aws_http_header_impl *end = header_impl + len;
+        while (header_impl != end) {
+            s_header_impl_clean_up(header_impl++);
+        }
+    }
+
+    aws_array_list_clean_up(&request->headers);
+
+    AWS_ZERO_STRUCT(*request);
+}
+
+int aws_http_request_set_method(struct aws_http_request *request, struct aws_byte_cursor method) {
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&method));
+
+    return s_set_string_from_cursor(&request->method, method, request->allocator);
+}
+
+struct aws_byte_cursor aws_http_request_get_method(const struct aws_http_request *request) {
+    AWS_PRECONDITION(request);
+
+    return s_get_cursor_from_string(request->method);
+}
+
+int aws_http_request_set_path(struct aws_http_request *request, struct aws_byte_cursor path) {
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(aws_byte_cursor_is_valid(&path));
+
+    return s_set_string_from_cursor(&request->path, path, request->allocator);
+}
+
+struct aws_byte_cursor aws_http_request_get_path(const struct aws_http_request *request) {
+    AWS_PRECONDITION(request);
+    return s_get_cursor_from_string(request->path);
+}
+
+void aws_http_request_set_body(struct aws_http_request *request, struct aws_input_stream *body) {
+    AWS_PRECONDITION(request);
+    request->body = body;
+}
+
+struct aws_input_stream *aws_http_request_get_body(const struct aws_http_request *request) {
+    AWS_PRECONDITION(request);
+    return request->body;
+}
+
+struct aws_http_header s_get_header_view_from_impl(struct aws_http_header_impl *impl) {
+    struct aws_http_header view = {
+        .name = s_get_cursor_from_string(impl->name),
+        .value = s_get_cursor_from_string(impl->value),
+    };
+    return view;
+}
+
+int aws_http_request_add_header(struct aws_http_request *request, struct aws_http_header header) {
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(aws_http_header_is_valid(&header));
+
+    struct aws_http_header_impl header_impl;
+    int err = s_header_impl_init(&header_impl, &header, request->allocator);
+    if (err) {
+        goto error;
+    }
+
+    err = aws_array_list_push_back(&request->headers, &header_impl);
+    if (err) {
+        goto error;
+    }
+
+    return AWS_OP_SUCCESS;
+
+error:
+    s_header_impl_clean_up(&header_impl);
+    return AWS_OP_ERR;
+}
+
+int aws_http_request_set_header(struct aws_http_request *request, struct aws_http_header header, size_t index) {
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(aws_http_header_is_valid(&header));
+
+    struct aws_http_header_impl *header_impl;
+    int err = aws_array_list_get_at_ptr(&request->headers, (void **)&header_impl, index);
+    if (err) {
+        return AWS_OP_ERR;
+    }
+
+    /* Prepare new value */
+    struct aws_http_header_impl new_impl;
+    err = s_header_impl_init(&new_impl, &header, request->allocator);
+    if (err) {
+        goto error;
+    }
+
+    /* Destroy existing strings (if any) */
+    aws_string_destroy(header_impl->name);
+    aws_string_destroy(header_impl->value);
+
+    /* Overwrite old value */
+    *header_impl = new_impl;
+    return AWS_OP_SUCCESS;
+
+error:
+    s_header_impl_clean_up(&new_impl);
+    return AWS_OP_ERR;
+}
+
+void aws_http_request_erase_header(struct aws_http_request *request, size_t index) {
+    AWS_PRECONDITION(request);
+
+    struct aws_http_header_impl *header_impl;
+    int err = aws_array_list_get_at_ptr(&request->headers, (void **)&header_impl, index);
+    if (!err) {
+        s_header_impl_clean_up(header_impl);
+        aws_array_list_erase(&request->headers, index);
+    }
+}
+
+size_t aws_http_request_get_header_count(const struct aws_http_request *request) {
+    AWS_PRECONDITION(request);
+
+    return aws_array_list_length(&request->headers);
+}
+
+struct aws_http_header aws_http_request_get_header(const struct aws_http_request *request, size_t index) {
+    AWS_PRECONDITION(request);
+
+    struct aws_http_header header_view;
+    AWS_ZERO_STRUCT(header_view);
+
+    struct aws_http_header_impl *header_impl;
+    int err = aws_array_list_get_at_ptr(&request->headers, (void **)&header_impl, index);
+    if (!err) {
+        header_view.name = s_get_cursor_from_string(header_impl->name);
+        header_view.value = s_get_cursor_from_string(header_impl->value);
+    }
+
+    return header_view;
+}
 
 struct aws_http_stream *aws_http_stream_new_client_request(const struct aws_http_request_options *options) {
     if (!options || options->self_size == 0 || !options->client_connection) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,6 @@ add_test_case(request_method)
 add_test_case(request_path)
 add_test_case(request_add_headers)
 add_test_case(request_erase_headers)
-add_test_case(request_do_invalid_stuff)
 
 add_test_case(h1_test_get_request)
 add_test_case(h1_test_request_bad_version)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,13 @@ file(GLOB TEST_HDRS "*.h")
 file(GLOB TEST_SRC "*.c")
 file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
 
+add_test_case(request_sanity_check)
+add_test_case(request_method)
+add_test_case(request_path)
+add_test_case(request_add_headers)
+add_test_case(request_erase_headers)
+add_test_case(request_do_invalid_stuff)
+
 add_test_case(h1_test_get_request)
 add_test_case(h1_test_request_bad_version)
 add_test_case(h1_test_response_unsupported_version)

--- a/tests/test_request.c
+++ b/tests/test_request.c
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/http/request_response.h>
+
+#include <aws/common/string.h>
+#include <aws/testing/aws_test_harness.h>
+
+#define TEST_CASE(NAME)                                                                                                \
+    AWS_TEST_CASE(NAME, s_test_##NAME);                                                                                \
+    static int s_test_##NAME(struct aws_allocator *allocator, void *ctx)
+
+TEST_CASE(request_sanity_check) {
+    (void)ctx;
+    struct aws_http_request request;
+    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+
+    aws_http_request_clean_up(&request);
+    return AWS_OP_SUCCESS;
+}
+
+TEST_CASE(request_method) {
+    (void)ctx;
+    struct aws_http_request request;
+    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+
+    /* Assert that an empty byte cursor is returned when no path has been set */
+    struct aws_byte_cursor get = aws_http_request_get_path(&request);
+    ASSERT_UINT_EQUALS(0, get.len);
+    ASSERT_TRUE(aws_byte_cursor_is_valid(&get));
+
+    /* Test simple set/get */
+    char path1[] = "/";
+    ASSERT_SUCCESS(aws_http_request_set_path(&request, aws_byte_cursor_from_c_str(path1)));
+    get = aws_http_request_get_path(&request);
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, path1));
+
+    /* Mutilate the original string to be sure request wasn't referencing its memory */
+    path1[0] = 'z';
+    struct aws_byte_cursor path1_repro = aws_byte_cursor_from_c_str("/");
+    ASSERT_TRUE(aws_byte_cursor_eq(&path1_repro, &get));
+
+    /* Set a new path */
+    ASSERT_SUCCESS(aws_http_request_set_path(&request, aws_byte_cursor_from_c_str("/index.html")));
+    get = aws_http_request_get_path(&request);
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, "/index.html"));
+
+    aws_http_request_clean_up(&request);
+    return AWS_OP_SUCCESS;
+}
+
+TEST_CASE(request_path) {
+    (void)ctx;
+    struct aws_http_request request;
+    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+
+    ASSERT_SUCCESS(aws_http_request_set_method(&request, aws_byte_cursor_from_c_str("GET")));
+    struct aws_byte_cursor get = aws_http_request_get_method(&request);
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, "GET"));
+
+    /* set_path and set_method use all the same helper functions, so this test is basic */
+
+    aws_http_request_clean_up(&request);
+    return AWS_OP_SUCCESS;
+}
+
+static struct aws_http_header s_make_header(const char *name, const char *value) {
+    return (struct aws_http_header){
+        .name = aws_byte_cursor_from_c_str(name),
+        .value = aws_byte_cursor_from_c_str(value),
+    };
+}
+
+static int s_check_headers_eq(struct aws_http_header a, struct aws_http_header b) {
+    ASSERT_TRUE(aws_byte_cursor_eq(&a.name, &b.name));
+    ASSERT_TRUE(aws_byte_cursor_eq(&a.value, &b.value));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_check_header_eq(struct aws_http_header header, const char *name, const char *value) {
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&header.name, name));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&header.value, value));
+    return AWS_OP_SUCCESS;
+}
+
+TEST_CASE(request_add_headers) {
+    (void)ctx;
+    struct aws_http_request request;
+    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+
+    ASSERT_UINT_EQUALS(0, aws_http_request_get_header_count(&request));
+
+    /* Add a header */
+    char name_src[] = "Host";
+    char value_src[] = "example.com";
+
+    ASSERT_SUCCESS(aws_http_request_add_header(&request, s_make_header(name_src, value_src)));
+    ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(&request));
+
+    /* Mutilate source strings to be sure the request isn't referencing their memory */
+    name_src[0] = 0;
+    value_src[0] = 0;
+
+    /* Check values */
+    struct aws_http_header get = aws_http_request_get_header(&request, 0);
+    ASSERT_SUCCESS(s_check_header_eq(get, "Host", "example.com"));
+
+    aws_http_request_clean_up(&request);
+    return AWS_OP_SUCCESS;
+}
+
+TEST_CASE(request_erase_headers) {
+    (void)ctx;
+    struct aws_http_request request;
+    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+
+    struct aws_http_header src_headers[] = {
+        s_make_header("NameA", "ValueA"),
+        s_make_header("NameB", "ValueB"),
+        s_make_header("NameC", "ValueC"),
+        s_make_header("NameD", "ValueD"),
+    };
+
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(src_headers); ++i) {
+        ASSERT_SUCCESS(aws_http_request_add_header(&request, src_headers[i]));
+    }
+
+    for (size_t i = 0; i < AWS_ARRAY_SIZE(src_headers); ++i) {
+        struct aws_http_header header_i = aws_http_request_get_header(&request, i);
+        ASSERT_SUCCESS(s_check_headers_eq(src_headers[i], header_i));
+    }
+
+    /* Remove a middle one and check */
+    const size_t kill_i = 1;
+    aws_http_request_erase_header(&request, kill_i);
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(src_headers) - 1, aws_http_request_get_header_count(&request));
+
+    for (size_t i = 0; i < aws_http_request_get_header_count(&request); ++i) {
+        /* Headers to the right should have shifted over */
+        size_t compare_i = (i < kill_i) ? i : (i + 1);
+
+        struct aws_http_header req_header = aws_http_request_get_header(&request, i);
+        ASSERT_SUCCESS(s_check_headers_eq(src_headers[compare_i], req_header));
+    }
+
+    /* Remove a front and a back header, only "NameC: ValueC" should remain */
+    aws_http_request_erase_header(&request, 0);
+    aws_http_request_erase_header(&request, aws_http_request_get_header_count(&request) - 1);
+
+    ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(&request));
+    ASSERT_SUCCESS(s_check_header_eq(aws_http_request_get_header(&request, 0), "NameC", "ValueC"));
+
+    /* Ensure that add() still works after remove() */
+    ASSERT_SUCCESS(aws_http_request_add_header(&request, s_make_header("Big", "Guy")));
+    struct aws_http_header get = aws_http_request_get_header(&request, aws_http_request_get_header_count(&request) - 1);
+    ASSERT_SUCCESS(s_check_header_eq(get, "Big", "Guy"));
+
+    aws_http_request_clean_up(&request);
+    return AWS_OP_SUCCESS;
+}
+
+TEST_CASE(request_do_invalid_stuff) {
+    (void)ctx;
+    struct aws_http_request request;
+    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+
+    /* Should be fine to try and erase non-existent headers */
+    for (size_t i = 0; i < 10; ++i) {
+        aws_http_request_erase_header(&request, i);
+    }
+
+    /* Querying non-existent headers should just get you empty data */
+    struct aws_http_header get = aws_http_request_get_header(&request, 99);
+    ASSERT_SUCCESS(s_check_header_eq(get, "", ""));
+
+    aws_http_request_clean_up(&request);
+    return AWS_OP_SUCCESS;
+}

--- a/tests/test_request.c
+++ b/tests/test_request.c
@@ -144,7 +144,7 @@ TEST_CASE(request_erase_headers) {
 
     /* Remove a middle one and check */
     const size_t kill_i = 1;
-    aws_http_request_erase_header(&request, kill_i);
+    ASSERT_SUCCESS(aws_http_request_erase_header(&request, kill_i));
     ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(src_headers) - 1, aws_http_request_get_header_count(&request));
 
     for (size_t i = 0; i < aws_http_request_get_header_count(&request); ++i) {
@@ -156,8 +156,8 @@ TEST_CASE(request_erase_headers) {
     }
 
     /* Remove a front and a back header, only "NameC: ValueC" should remain */
-    aws_http_request_erase_header(&request, 0);
-    aws_http_request_erase_header(&request, aws_http_request_get_header_count(&request) - 1);
+    ASSERT_SUCCESS(aws_http_request_erase_header(&request, 0));
+    ASSERT_SUCCESS(aws_http_request_erase_header(&request, aws_http_request_get_header_count(&request) - 1));
 
     ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(&request));
     ASSERT_SUCCESS(s_check_header_eq(aws_http_request_get_header(&request, 0), "NameC", "ValueC"));
@@ -178,7 +178,7 @@ TEST_CASE(request_do_invalid_stuff) {
 
     /* Should be fine to try and erase non-existent headers */
     for (size_t i = 0; i < 10; ++i) {
-        aws_http_request_erase_header(&request, i);
+        ASSERT_ERROR(AWS_ERROR_INVALID_INDEX, aws_http_request_erase_header(&request, i));
     }
 
     /* Querying non-existent headers should just get you empty data */

--- a/tests/test_request.c
+++ b/tests/test_request.c
@@ -24,27 +24,26 @@
 
 TEST_CASE(request_sanity_check) {
     (void)ctx;
-    struct aws_http_request request;
-    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
 
-    aws_http_request_clean_up(&request);
+    aws_http_request_destroy(request);
     return AWS_OP_SUCCESS;
 }
 
-TEST_CASE(request_method) {
+TEST_CASE(request_path) {
     (void)ctx;
-    struct aws_http_request request;
-    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
 
-    /* Assert that an empty byte cursor is returned when no path has been set */
-    struct aws_byte_cursor get = aws_http_request_get_path(&request);
-    ASSERT_UINT_EQUALS(0, get.len);
-    ASSERT_TRUE(aws_byte_cursor_is_valid(&get));
+    /* Assert that query fails when there's no data */
+    struct aws_byte_cursor get;
+    ASSERT_ERROR(AWS_ERROR_HTTP_DATA_NOT_AVAILABLE, aws_http_request_get_path(request, &get));
 
     /* Test simple set/get */
     char path1[] = "/";
-    ASSERT_SUCCESS(aws_http_request_set_path(&request, aws_byte_cursor_from_c_str(path1)));
-    get = aws_http_request_get_path(&request);
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str(path1)));
+    ASSERT_SUCCESS(aws_http_request_get_path(request, &get));
     ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, path1));
 
     /* Mutilate the original string to be sure request wasn't referencing its memory */
@@ -53,26 +52,39 @@ TEST_CASE(request_method) {
     ASSERT_TRUE(aws_byte_cursor_eq(&path1_repro, &get));
 
     /* Set a new path */
-    ASSERT_SUCCESS(aws_http_request_set_path(&request, aws_byte_cursor_from_c_str("/index.html")));
-    get = aws_http_request_get_path(&request);
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/index.html")));
+    ASSERT_SUCCESS(aws_http_request_get_path(request, &get));
     ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, "/index.html"));
 
-    aws_http_request_clean_up(&request);
+    aws_http_request_destroy(request);
     return AWS_OP_SUCCESS;
 }
-
-TEST_CASE(request_path) {
+TEST_CASE(request_method) {
     (void)ctx;
-    struct aws_http_request request;
-    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
 
-    ASSERT_SUCCESS(aws_http_request_set_method(&request, aws_byte_cursor_from_c_str("GET")));
-    struct aws_byte_cursor get = aws_http_request_get_method(&request);
-    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, "GET"));
+    /* Assert that query fails when there's no data */
+    struct aws_byte_cursor get;
+    ASSERT_ERROR(AWS_ERROR_HTTP_DATA_NOT_AVAILABLE, aws_http_request_get_method(request, &get));
 
-    /* set_path and set_method use all the same helper functions, so this test is basic */
+    /* Test simple set/get */
+    char method1[] = "GET";
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str(method1)));
+    ASSERT_SUCCESS(aws_http_request_get_method(request, &get));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, method1));
 
-    aws_http_request_clean_up(&request);
+    /* Mutilate the original string to be sure request wasn't referencing its memory */
+    method1[0] = 'B';
+    struct aws_byte_cursor method1_repro = aws_byte_cursor_from_c_str("GET");
+    ASSERT_TRUE(aws_byte_cursor_eq(&method1_repro, &get));
+
+    /* Set a new method */
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("POST")));
+    ASSERT_SUCCESS(aws_http_request_get_method(request, &get));
+    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, "POST"));
+
+    aws_http_request_destroy(request);
     return AWS_OP_SUCCESS;
 }
 
@@ -97,35 +109,42 @@ static int s_check_header_eq(struct aws_http_header header, const char *name, co
 
 TEST_CASE(request_add_headers) {
     (void)ctx;
-    struct aws_http_request request;
-    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
 
-    ASSERT_UINT_EQUALS(0, aws_http_request_get_header_count(&request));
+    /* Test queries on 0 headers */
+    struct aws_http_header get;
+    ASSERT_ERROR(AWS_ERROR_INVALID_INDEX, aws_http_request_get_header(request, &get, 0));
+    ASSERT_UINT_EQUALS(0, aws_http_request_get_header_count(request));
 
     /* Add a header */
     char name_src[] = "Host";
     char value_src[] = "example.com";
 
-    ASSERT_SUCCESS(aws_http_request_add_header(&request, s_make_header(name_src, value_src)));
-    ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(&request));
+    ASSERT_SUCCESS(aws_http_request_add_header(request, s_make_header(name_src, value_src)));
+    ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(request));
 
     /* Mutilate source strings to be sure the request isn't referencing their memory */
     name_src[0] = 0;
     value_src[0] = 0;
 
     /* Check values */
-    struct aws_http_header get = aws_http_request_get_header(&request, 0);
+    ASSERT_SUCCESS(aws_http_request_get_header(request, &get, 0));
     ASSERT_SUCCESS(s_check_header_eq(get, "Host", "example.com"));
 
-    aws_http_request_clean_up(&request);
+    aws_http_request_destroy(request);
     return AWS_OP_SUCCESS;
 }
 
 TEST_CASE(request_erase_headers) {
     (void)ctx;
-    struct aws_http_request request;
-    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
 
+    /* Should have no effect to try and erase non-existent headers */
+    ASSERT_ERROR(AWS_ERROR_INVALID_INDEX, aws_http_request_erase_header(request, 0));
+
+    /* Add a bunch of headers */
     struct aws_http_header src_headers[] = {
         s_make_header("NameA", "ValueA"),
         s_make_header("NameB", "ValueB"),
@@ -134,57 +153,44 @@ TEST_CASE(request_erase_headers) {
     };
 
     for (size_t i = 0; i < AWS_ARRAY_SIZE(src_headers); ++i) {
-        ASSERT_SUCCESS(aws_http_request_add_header(&request, src_headers[i]));
+        ASSERT_SUCCESS(aws_http_request_add_header(request, src_headers[i]));
     }
 
+    struct aws_http_header get;
     for (size_t i = 0; i < AWS_ARRAY_SIZE(src_headers); ++i) {
-        struct aws_http_header header_i = aws_http_request_get_header(&request, i);
-        ASSERT_SUCCESS(s_check_headers_eq(src_headers[i], header_i));
+        ASSERT_SUCCESS(aws_http_request_get_header(request, &get, i));
+        ASSERT_SUCCESS(s_check_headers_eq(src_headers[i], get));
     }
 
     /* Remove a middle one and check */
     const size_t kill_i = 1;
-    ASSERT_SUCCESS(aws_http_request_erase_header(&request, kill_i));
-    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(src_headers) - 1, aws_http_request_get_header_count(&request));
+    ASSERT_SUCCESS(aws_http_request_erase_header(request, kill_i));
+    ASSERT_UINT_EQUALS(AWS_ARRAY_SIZE(src_headers) - 1, aws_http_request_get_header_count(request));
 
-    for (size_t i = 0; i < aws_http_request_get_header_count(&request); ++i) {
+    for (size_t i = 0; i < aws_http_request_get_header_count(request); ++i) {
         /* Headers to the right should have shifted over */
         size_t compare_i = (i < kill_i) ? i : (i + 1);
 
-        struct aws_http_header req_header = aws_http_request_get_header(&request, i);
-        ASSERT_SUCCESS(s_check_headers_eq(src_headers[compare_i], req_header));
+        ASSERT_SUCCESS(aws_http_request_get_header(request, &get, i));
+        ASSERT_SUCCESS(s_check_headers_eq(src_headers[compare_i], get));
     }
+
+    /* Removing an invalid index should have no effect */
+    ASSERT_ERROR(AWS_ERROR_INVALID_INDEX, aws_http_request_erase_header(request, 99));
 
     /* Remove a front and a back header, only "NameC: ValueC" should remain */
-    ASSERT_SUCCESS(aws_http_request_erase_header(&request, 0));
-    ASSERT_SUCCESS(aws_http_request_erase_header(&request, aws_http_request_get_header_count(&request) - 1));
+    ASSERT_SUCCESS(aws_http_request_erase_header(request, 0));
+    ASSERT_SUCCESS(aws_http_request_erase_header(request, aws_http_request_get_header_count(request) - 1));
 
-    ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(&request));
-    ASSERT_SUCCESS(s_check_header_eq(aws_http_request_get_header(&request, 0), "NameC", "ValueC"));
+    ASSERT_UINT_EQUALS(1, aws_http_request_get_header_count(request));
+    ASSERT_SUCCESS(aws_http_request_get_header(request, &get, 0));
+    ASSERT_SUCCESS(s_check_header_eq(get, "NameC", "ValueC"));
 
     /* Ensure that add() still works after remove() */
-    ASSERT_SUCCESS(aws_http_request_add_header(&request, s_make_header("Big", "Guy")));
-    struct aws_http_header get = aws_http_request_get_header(&request, aws_http_request_get_header_count(&request) - 1);
+    ASSERT_SUCCESS(aws_http_request_add_header(request, s_make_header("Big", "Guy")));
+    ASSERT_SUCCESS(aws_http_request_get_header(request, &get, aws_http_request_get_header_count(request) - 1));
     ASSERT_SUCCESS(s_check_header_eq(get, "Big", "Guy"));
 
-    aws_http_request_clean_up(&request);
-    return AWS_OP_SUCCESS;
-}
-
-TEST_CASE(request_do_invalid_stuff) {
-    (void)ctx;
-    struct aws_http_request request;
-    ASSERT_SUCCESS(aws_http_request_init(&request, allocator));
-
-    /* Should be fine to try and erase non-existent headers */
-    for (size_t i = 0; i < 10; ++i) {
-        ASSERT_ERROR(AWS_ERROR_INVALID_INDEX, aws_http_request_erase_header(&request, i));
-    }
-
-    /* Querying non-existent headers should just get you empty data */
-    struct aws_http_header get = aws_http_request_get_header(&request, 99);
-    ASSERT_SUCCESS(s_check_header_eq(get, "", ""));
-
-    aws_http_request_clean_up(&request);
+    aws_http_request_destroy(request);
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
Request object that can be transformed by signers before it's passed to the actual HTTP connection.

Controversial design decisions:
- A million individual string allocations. I could have packed all the string copies into one linear byte_buf, but if that buf ever resized, all the old pointers would suddenly go invalid (rare bugs are best bugs!). We can optimize this with a small-block allocator in the future.

Future work:
- Decide if the transform_request_fn() needs to support asynchronous transforms.
- Decide if there should be some corresponding validate_respones_fn().
- Revamp aws_stream_new_client_request() to take this structure. I didn't want to break the existing API before leaving on vaction.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
