### PR TITLE
All requests now require that the user create a request object

### DIFF
--- a/bin/elasticurl/main.c
+++ b/bin/elasticurl/main.c
@@ -491,19 +491,13 @@ static void s_on_client_connection_setup(struct aws_http_connection *connection,
     struct aws_http_request_options final_request;
     AWS_ZERO_STRUCT(final_request);
     final_request.self_size = sizeof(struct aws_http_request_options);
-    final_request.uri = app_ctx->uri.path_and_query;
     final_request.user_data = app_ctx;
     final_request.client_connection = connection;
-    final_request.method = aws_byte_cursor_from_c_str(app_ctx->verb);
-    final_request.header_array = headers;
-    final_request.num_headers = aws_http_request_get_header_count(request);
+    final_request.request = request;
     final_request.on_response_headers = s_on_incoming_headers_fn;
     final_request.on_response_header_block_done = s_on_incoming_header_block_done_fn;
     final_request.on_response_body = s_on_incoming_body_fn;
     final_request.on_complete = s_on_stream_complete_fn;
-    if (app_ctx->input_body) {
-        final_request.stream_outgoing_body = s_stream_outgoing_body_fn;
-    }
 
     app_ctx->response_code_written = false;
 

--- a/include/aws/http/http.h
+++ b/include/aws/http/http.h
@@ -81,6 +81,24 @@ void aws_http_library_clean_up(void);
 AWS_HTTP_API
 const char *aws_http_status_text(int status_code);
 
+/**
+ * Shortcuts for common HTTP request methods
+ */
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_get;
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_head;
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_post;
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_put;
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_delete;
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_connect;
+AWS_HTTP_API
+extern const struct aws_byte_cursor aws_http_method_options;
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_HTTP_H */

--- a/include/aws/http/private/http_impl.h
+++ b/include/aws/http/private/http_impl.h
@@ -24,6 +24,7 @@
  */
 enum aws_http_method {
     AWS_HTTP_METHOD_UNKNOWN, /* Unrecognized value. */
+    AWS_HTTP_METHOD_GET,
     AWS_HTTP_METHOD_HEAD,
     AWS_HTTP_METHOD_COUNT, /* Number of enums */
 };

--- a/include/aws/http/private/request_response_impl.h
+++ b/include/aws/http/private/request_response_impl.h
@@ -35,9 +35,9 @@ struct aws_http_stream {
     const struct aws_http_stream_vtable *vtable;
     struct aws_allocator *alloc;
     struct aws_http_connection *owning_connection;
+    struct aws_input_stream *outgoing_body;
 
     void *user_data;
-    aws_http_stream_outgoing_body_fn *stream_outgoing_body;
     aws_http_on_incoming_headers_fn *on_incoming_headers;
     aws_http_on_incoming_header_block_done_fn *on_incoming_header_block_done;
     aws_http_on_incoming_body_fn *on_incoming_body;

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -112,32 +112,11 @@ struct aws_http_request_options {
     struct aws_http_connection *client_connection;
 
     /**
-     * Required for HTTP/1.
-     * Not required in HTTP/2 if :method header is passed in.
+     * Required.
      */
-    struct aws_byte_cursor method;
-
-    /**
-     * Required for HTTP/1.
-     * Not required in HTTP/2 if :path header is passed in.
-     */
-    struct aws_byte_cursor uri;
-
-    /**
-     * Array of request headers.
-     * Optional.
-     * For HTTP/2, if :method and :path headers not passed in they will be generated from the `method` and `uri`.
-     */
-    const struct aws_http_header *header_array;
-    size_t num_headers;
+    struct aws_http_request *request;
 
     void *user_data;
-
-    /**
-     * Callback responsible for sending the request body.
-     * Required if request has a body.
-     */
-    aws_http_stream_outgoing_body_fn *stream_outgoing_body;
 
     /**
      * Invoked repeatedly times as headers are received.
@@ -287,6 +266,19 @@ int aws_http_request_get_header(
  */
 AWS_HTTP_API
 int aws_http_request_add_header(struct aws_http_request *request, struct aws_http_header header);
+
+/**
+ * Add an array of headers to the end of the header array.
+ * The request makes its own copy of the underlying strings.
+ *
+ * This is a helper function useful when it's easier to define headers as a stack array, rather than calling add_header
+ * repeatedly.
+ */
+AWS_HTTP_API
+int aws_http_request_add_header_array(
+    struct aws_http_request *request,
+    struct aws_http_header *headers,
+    size_t num_headers);
 
 /**
  * Modify the header at the specified index.

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -113,6 +113,7 @@ struct aws_http_request_options {
 
     /**
      * Required.
+     * This object must stay alive at least until on_complete is called.
      */
     struct aws_http_request *request;
 
@@ -277,7 +278,7 @@ int aws_http_request_add_header(struct aws_http_request *request, struct aws_htt
 AWS_HTTP_API
 int aws_http_request_add_header_array(
     struct aws_http_request *request,
-    struct aws_http_header *headers,
+    const struct aws_http_header *headers,
     size_t num_headers);
 
 /**

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -60,15 +60,6 @@ enum aws_http_outgoing_body_state {
     AWS_HTTP_OUTGOING_BODY_DONE,
 };
 
-/**
- * Called repeatedly whenever body data can be sent.
- * User should write body to buffer using aws_byte_buf_write_X functions.
- * Note that the buffer might already be partially full.
- * Return AWS_HTTP_OUTGOING_BODY_DONE when the body has been written to its end.
- */
-typedef enum aws_http_outgoing_body_state(
-    aws_http_stream_outgoing_body_fn)(struct aws_http_stream *stream, struct aws_byte_buf *buf, void *user_data);
-
 typedef void(aws_http_on_incoming_headers_fn)(
     struct aws_http_stream *stream,
     const struct aws_http_header *header_array,
@@ -179,7 +170,7 @@ struct aws_http_response_options {
     int status;
     const struct aws_http_header *header_array;
     size_t num_headers;
-    aws_http_stream_outgoing_body_fn *stream_outgoing_body;
+    struct aws_input_stream *body_stream;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/include/aws/http/websocket.h
+++ b/include/aws/http/websocket.h
@@ -170,29 +170,30 @@ struct aws_websocket_client_connection_options {
      * Required.
      * aws_websocket_client_connect() makes a copy.
      */
-    struct aws_uri *uri;
+    struct aws_byte_cursor host;
 
     /**
-     * Array of headers for the HTTP Upgrade request.
+     * Optional.
+     * Defaults to 443 if tls_options is present, 80 if it is not.
+     */
+    uint16_t port;
+
+    /**
      * Required.
-     * aws_websocket_client_connect() deep-copies all contents.
-     * The following headers are required:
+     * The request must outlive the handshake process (it will be safe to release in on_connection_setup())
+     * Suggestion: create via aws_http_request_new_websocket_handshake()
      *
-     * Host: server.example.com
+     * The following headers are required (replace values in []):
+     *
+     * Host: [server.example.com]
      * Upgrade: websocket
      * Connection: Upgrade
-     * Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+     * Sec-WebSocket-Key: [dGhlIHNhbXBsZSBub25jZQ==]
      * Sec-WebSocket-Version: 13
      *
      * Sec-Websocket-Key should be a random 16 bytes value, Base64 encoded.
      */
-    const struct aws_http_header *handshake_header_array;
-
-    /**
-     * Number of entries in handshake_header_array.
-     * Required.
-     */
-    size_t num_handshake_headers;
+    struct aws_http_request *handshake_request;
 
     /**
      * Initial window size for websocket.

--- a/include/aws/http/websocket.h
+++ b/include/aws/http/websocket.h
@@ -183,6 +183,7 @@ struct aws_websocket_client_connection_options {
      * The request must outlive the handshake process (it will be safe to release in on_connection_setup())
      * Suggestion: create via aws_http_request_new_websocket_handshake()
      *
+     * The method MUST be set to GET.
      * The following headers are required (replace values in []):
      *
      * Host: [server.example.com]

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -417,7 +417,7 @@ struct aws_http_stream *s_new_client_request_stream(const struct aws_http_reques
      */
 
     size_t header_lines_len;
-    err |= s_stream_scan_outgoing_headers(stream, options->request, &header_lines_len);
+    err = s_stream_scan_outgoing_headers(stream, options->request, &header_lines_len);
     if (err) {
         /* errors already logged by scan_outgoing_headers() function */
         goto error_scanning_headers;

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -183,7 +183,6 @@ enum stream_outgoing_state {
 struct h1_stream {
     struct aws_http_stream base;
 
-    // struct aws_http_request *request;
 
     enum stream_type type;
     struct aws_linked_list_node node;

--- a/source/http.c
+++ b/source/http.c
@@ -147,6 +147,7 @@ static struct aws_hash_table s_method_str_to_enum;                         /* fo
 static struct aws_byte_cursor s_method_enum_to_str[AWS_HTTP_METHOD_COUNT]; /* for enum -> string lookup */
 
 static void s_methods_init(struct aws_allocator *alloc) {
+    s_method_enum_to_str[AWS_HTTP_METHOD_GET] = aws_http_method_get;
     s_method_enum_to_str[AWS_HTTP_METHOD_HEAD] = aws_byte_cursor_from_c_str("HEAD");
 
     s_init_str_to_enum_hash_table(
@@ -386,3 +387,10 @@ void aws_http_fatal_assert_library_initialized() {
         AWS_FATAL_ASSERT(s_library_initialized);
     }
 }
+
+const struct aws_byte_cursor aws_http_method_get = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("GET");
+const struct aws_byte_cursor aws_http_method_post = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("POST");
+const struct aws_byte_cursor aws_http_method_put = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("PUT");
+const struct aws_byte_cursor aws_http_method_delete = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("DELETE");
+const struct aws_byte_cursor aws_http_method_connect = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("CONNECT");
+const struct aws_byte_cursor aws_http_method_options = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("OPTIONS");

--- a/source/http.c
+++ b/source/http.c
@@ -148,7 +148,7 @@ static struct aws_byte_cursor s_method_enum_to_str[AWS_HTTP_METHOD_COUNT]; /* fo
 
 static void s_methods_init(struct aws_allocator *alloc) {
     s_method_enum_to_str[AWS_HTTP_METHOD_GET] = aws_http_method_get;
-    s_method_enum_to_str[AWS_HTTP_METHOD_HEAD] = aws_byte_cursor_from_c_str("HEAD");
+    s_method_enum_to_str[AWS_HTTP_METHOD_HEAD] = aws_http_method_head;
 
     s_init_str_to_enum_hash_table(
         &s_method_str_to_enum,
@@ -389,6 +389,7 @@ void aws_http_fatal_assert_library_initialized() {
 }
 
 const struct aws_byte_cursor aws_http_method_get = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("GET");
+const struct aws_byte_cursor aws_http_method_head = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("HEAD");
 const struct aws_byte_cursor aws_http_method_post = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("POST");
 const struct aws_byte_cursor aws_http_method_put = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("PUT");
 const struct aws_byte_cursor aws_http_method_delete = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("DELETE");

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -222,7 +222,7 @@ error:
 
 int aws_http_request_add_header_array(
     struct aws_http_request *request,
-    struct aws_http_header *headers,
+    const struct aws_http_header *headers,
     size_t num_headers) {
 
     AWS_PRECONDITION(request);

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -220,6 +220,34 @@ error:
     return AWS_OP_ERR;
 }
 
+int aws_http_request_add_header_array(
+    struct aws_http_request *request,
+    struct aws_http_header *headers,
+    size_t num_headers) {
+
+    AWS_PRECONDITION(request);
+    AWS_PRECONDITION(headers);
+    AWS_PRECONDITION(num_headers > 0);
+
+    const size_t beginning_headers_size = aws_array_list_length(&request->headers);
+
+    for (size_t i = 0; i < num_headers; ++i) {
+        if (aws_http_request_add_header(request, headers[i])) {
+            goto error;
+        }
+    }
+
+    return AWS_OP_SUCCESS;
+
+error:
+    /* Remove all headers we added */
+    for (size_t len = aws_array_list_length(&request->headers); len > beginning_headers_size; --len) {
+        aws_http_request_erase_header(request, len - 1);
+    }
+
+    return AWS_OP_ERR;
+}
+
 int aws_http_request_set_header(struct aws_http_request *request, struct aws_http_header header, size_t index) {
     AWS_PRECONDITION(request);
     AWS_PRECONDITION(aws_byte_cursor_is_valid(&header.name) && aws_byte_cursor_is_valid(&header.value));

--- a/source/websocket.c
+++ b/source/websocket.c
@@ -1657,8 +1657,7 @@ struct aws_http_request *aws_http_request_new_websocket_handshake(
         goto error;
     }
 
-    struct aws_byte_cursor method = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("GET");
-    int err = aws_http_request_set_method(request, method);
+    int err = aws_http_request_set_method(request, aws_http_method_get);
     if (err) {
         goto error;
     }

--- a/source/websocket_bootstrap.c
+++ b/source/websocket_bootstrap.c
@@ -27,8 +27,6 @@
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
-static const struct aws_byte_cursor s_method_get = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("GET");
-
 /**
  * Allow unit-tests to mock interactions with external systems.
  */
@@ -117,7 +115,7 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
 
     struct aws_byte_cursor method;
     aws_http_request_get_method(options->handshake_request, &method);
-    if (!aws_byte_cursor_eq(&method, &s_method_get)) {
+    if (aws_http_str_to_method(method) != AWS_HTTP_METHOD_GET) {
 
         AWS_LOGF_ERROR(AWS_LS_HTTP_WEBSOCKET_SETUP, "id=static: Websocket request must have method be 'GET'.");
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
@@ -140,7 +138,7 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     if (!options->handshake_request) {
         AWS_LOGF_ERROR(
             AWS_LS_HTTP_WEBSOCKET_SETUP,
-            "id=static: Invalid connection options, missing required request websocket client handshake.");
+            "id=static: Invalid connection options, missing required request for websocket client handshake.");
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 

--- a/source/websocket_bootstrap.c
+++ b/source/websocket_bootstrap.c
@@ -21,21 +21,13 @@
 #include <aws/http/request_response.h>
 #include <aws/io/uri.h>
 
+#include <inttypes.h>
+
 #if _MSC_VER
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
-struct scheme_port {
-    struct aws_byte_cursor scheme;
-    uint16_t port;
-};
-
-static const struct scheme_port s_scheme_ports[] = {
-    {.scheme = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("http"), .port = 80},
-    {.scheme = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("https"), .port = 443},
-    {.scheme = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("ws"), .port = 80},
-    {.scheme = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("wss"), .port = 443},
-};
+static const struct aws_byte_cursor s_method_get = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("GET");
 
 /**
  * Allow unit-tests to mock interactions with external systems.
@@ -81,10 +73,7 @@ struct aws_websocket_client_bootstrap {
     aws_websocket_on_incoming_frame_complete_fn *websocket_frame_complete_callback;
 
     /* Handshake request data */
-    struct aws_byte_cursor request_path;
-    struct aws_http_header *request_header_array;
-    size_t num_request_headers;
-    struct aws_byte_buf request_storage;
+    struct aws_http_request *handshake_request;
 
     /* Handshake response data */
     int response_status;
@@ -117,10 +106,20 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     AWS_ASSERT(options);
 
     /* Validate options */
-    if (!options->allocator || !options->bootstrap || !options->socket_options || !options->uri ||
+    struct aws_byte_cursor path;
+    aws_http_request_get_path(options->handshake_request, &path);
+    if (!options->allocator || !options->bootstrap || !options->socket_options || !options->host.len || !path.len ||
         !options->on_connection_setup) {
 
         AWS_LOGF_ERROR(AWS_LS_HTTP_WEBSOCKET_SETUP, "id=static: Missing required websocket connection options.");
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
+
+    struct aws_byte_cursor method;
+    aws_http_request_get_method(options->handshake_request, &method);
+    if (!aws_byte_cursor_eq(&method, &s_method_get)) {
+
+        AWS_LOGF_ERROR(AWS_LS_HTTP_WEBSOCKET_SETUP, "id=static: Websocket request must have method be 'GET'.");
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
@@ -138,10 +137,10 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    if (!options->handshake_header_array || !options->num_handshake_headers) {
+    if (!options->handshake_request) {
         AWS_LOGF_ERROR(
             AWS_LS_HTTP_WEBSOCKET_SETUP,
-            "id=static: Invalid connection options, missing required headers for websocket client handshake.");
+            "id=static: Invalid connection options, missing required request websocket client handshake.");
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
@@ -160,52 +159,15 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     ws_bootstrap->websocket_frame_begin_callback = options->on_incoming_frame_begin;
     ws_bootstrap->websocket_frame_payload_callback = options->on_incoming_frame_payload;
     ws_bootstrap->websocket_frame_complete_callback = options->on_incoming_frame_complete;
+    ws_bootstrap->handshake_request = options->handshake_request;
     ws_bootstrap->response_status = AWS_HTTP_STATUS_UNKNOWN;
 
-    /* Deep-copy all request headers, plus the request path. */
-    size_t request_storage_size = aws_uri_path_and_query(options->uri)->len;
-    for (size_t i = 0; i < options->num_handshake_headers; ++i) {
-        request_storage_size += options->handshake_header_array[i].name.len;
-        request_storage_size += options->handshake_header_array[i].value.len;
-    }
-
-    int err = aws_byte_buf_init(&ws_bootstrap->request_storage, ws_bootstrap->alloc, request_storage_size);
-    if (err) {
-        goto error;
-    }
-
-    ws_bootstrap->request_path.len = aws_uri_path_and_query(options->uri)->len;
-    ws_bootstrap->request_path.ptr = ws_bootstrap->request_storage.buffer + ws_bootstrap->request_storage.len;
-    bool write_success =
-        aws_byte_buf_write_from_whole_cursor(&ws_bootstrap->request_storage, *aws_uri_path_and_query(options->uri));
-
-    ws_bootstrap->num_request_headers = options->num_handshake_headers;
-    ws_bootstrap->request_header_array =
-        aws_mem_calloc(ws_bootstrap->alloc, ws_bootstrap->num_request_headers, sizeof(struct aws_http_header));
-    if (!ws_bootstrap->request_header_array) {
-        goto error;
-    }
-
-    for (size_t i = 0; i < options->num_handshake_headers; ++i) {
-        const struct aws_http_header *src = &options->handshake_header_array[i];
-        struct aws_http_header *dst = &ws_bootstrap->request_header_array[i];
-
-        dst->name.len = src->name.len;
-        dst->name.ptr = ws_bootstrap->request_storage.buffer + ws_bootstrap->request_storage.len;
-        write_success &= aws_byte_buf_write_from_whole_cursor(&ws_bootstrap->request_storage, src->name);
-
-        dst->value.len = src->value.len;
-        dst->value.ptr = ws_bootstrap->request_storage.buffer + ws_bootstrap->request_storage.len;
-        write_success &= aws_byte_buf_write_from_whole_cursor(&ws_bootstrap->request_storage, src->value);
-    }
-
-    AWS_ASSERT(write_success); /* Should only fail if we allocated the wrong amount. */
-
     /* Pre-allocate space for response headers */
-    size_t estimated_response_headers = ws_bootstrap->num_request_headers + 10; /* just guesses */
-    size_t estimated_response_header_length = 64;                               /* just guesses */
+    /* Values are just guesses */
+    size_t estimated_response_headers = aws_http_request_get_header_count(ws_bootstrap->handshake_request) + 10;
+    size_t estimated_response_header_length = 64;
 
-    err = aws_array_list_init_dynamic(
+    int err = aws_array_list_init_dynamic(
         &ws_bootstrap->response_headers,
         ws_bootstrap->alloc,
         estimated_response_headers,
@@ -226,7 +188,7 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     struct aws_http_client_connection_options http_options = AWS_HTTP_CLIENT_CONNECTION_OPTIONS_INIT;
     http_options.allocator = ws_bootstrap->alloc;
     http_options.bootstrap = options->bootstrap;
-    http_options.host_name = *aws_uri_host_name(options->uri);
+    http_options.host_name = options->host;
     http_options.socket_options = options->socket_options;
     http_options.tls_options = options->tls_options;
     http_options.initial_window_size = 1024; /* Adequate space for response data to trickle in */
@@ -235,19 +197,9 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     http_options.on_shutdown = s_ws_bootstrap_on_http_shutdown;
 
     /* Infer port, if not explicitly specified in URI */
-    http_options.port = aws_uri_port(options->uri);
+    http_options.port = options->port;
     if (!http_options.port) {
-        struct aws_byte_cursor scheme = *aws_uri_scheme(options->uri);
-        for (size_t i = 0; i < AWS_ARRAY_SIZE(s_scheme_ports); ++i) {
-            if (aws_byte_cursor_eq_ignore_case(&scheme, &s_scheme_ports[i].scheme)) {
-                http_options.port = s_scheme_ports[i].port;
-                break;
-            }
-        }
-
-        if (!http_options.port) {
-            http_options.port = options->tls_options ? 443 : 80;
-        }
+        http_options.port = options->tls_options ? 443 : 80;
     }
 
     err = s_system_vtable->aws_http_client_connect(&http_options);
@@ -263,9 +215,11 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     /* Success! (so far) */
     AWS_LOGF_TRACE(
         AWS_LS_HTTP_WEBSOCKET_SETUP,
-        "id=%p: Websocket setup begun, connecting to " PRInSTR,
+        "id=%p: Websocket setup begun, connecting to " PRInSTR ":%" PRIu16 PRInSTR,
         (void *)ws_bootstrap,
-        AWS_BYTE_BUF_PRI(options->uri->uri_str));
+        AWS_BYTE_CURSOR_PRI(options->host),
+        options->port,
+        AWS_BYTE_CURSOR_PRI(path));
 
     return AWS_OP_SUCCESS;
 
@@ -286,10 +240,6 @@ static void s_ws_bootstrap_destroy(struct aws_websocket_client_bootstrap *ws_boo
         return;
     }
 
-    if (ws_bootstrap->request_header_array) {
-        aws_mem_release(ws_bootstrap->alloc, ws_bootstrap->request_header_array);
-    }
-    aws_byte_buf_clean_up(&ws_bootstrap->request_storage);
     aws_array_list_clean_up(&ws_bootstrap->response_headers);
     aws_byte_buf_clean_up(&ws_bootstrap->response_storage);
 
@@ -352,10 +302,7 @@ static void s_ws_bootstrap_on_http_setup(struct aws_http_connection *http_connec
     /* Send the handshake request */
     struct aws_http_request_options options = AWS_HTTP_REQUEST_OPTIONS_INIT;
     options.client_connection = http_connection;
-    options.method = aws_byte_cursor_from_c_str("GET");
-    options.uri = ws_bootstrap->request_path;
-    options.header_array = ws_bootstrap->request_header_array;
-    options.num_headers = ws_bootstrap->num_request_headers;
+    options.request = ws_bootstrap->handshake_request;
     options.user_data = ws_bootstrap;
     options.on_response_headers = s_ws_bootstrap_on_handshake_response_headers;
     options.on_complete = s_ws_bootstrap_on_handshake_complete;

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -1508,10 +1508,11 @@ static int s_test_close_from_callback(struct aws_allocator *allocator, enum requ
 
     struct close_from_callback_tester close_tester = {
         .close_at = close_at,
-        .status = {
-            .is_valid = true,
-            .is_end_of_stream = false,
-        }
+        .status =
+            {
+                .is_valid = true,
+                .is_end_of_stream = false,
+            },
     };
     struct aws_input_stream close_from_outgoing_body_stream = {
         .allocator = allocator,

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -1016,6 +1016,7 @@ int s_slow_stream_read(struct aws_input_stream *stream, struct aws_byte_buf *des
         }
     }
 
+    *amount_read = writing;
     aws_byte_buf_write(dest, sender->cursor.ptr, writing);
     aws_byte_cursor_advance(&sender->cursor, writing);
 

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -32,7 +32,7 @@
 static struct aws_http_request *s_new_default_get_request(struct aws_allocator *allocator) {
     struct aws_http_request *request = aws_http_request_new(allocator);
     AWS_FATAL_ASSERT(request);
-    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_http_request_set_method(request, aws_byte_cursor_from_c_str("GET")));
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_http_request_set_method(request, aws_http_method_get));
     AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/")));
 
     return request;
@@ -1529,7 +1529,7 @@ static int s_test_close_from_callback(struct aws_allocator *allocator, enum requ
 
     struct aws_http_request *request = aws_http_request_new(allocator);
     ASSERT_NOT_NULL(request);
-    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("POST")));
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_http_method_post));
     ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/")));
     ASSERT_SUCCESS(aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers)));
     aws_http_request_set_body_stream(request, &close_from_outgoing_body_stream);
@@ -1702,7 +1702,7 @@ static int s_switch_protocols(struct protocol_switcher *switcher) {
 
     struct aws_http_request *request = aws_http_request_new(switcher->tester->alloc);
     ASSERT_NOT_NULL(request);
-    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("GET")));
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_http_method_get));
     ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/")));
     ASSERT_SUCCESS(aws_http_request_add_header_array(request, request_headers, AWS_ARRAY_SIZE(request_headers)));
 
@@ -1954,7 +1954,7 @@ H1_CLIENT_TEST_CASE(h1_client_switching_protocols_fails_pending_requests) {
 
     struct aws_http_request *upgrade_request = aws_http_request_new(allocator);
     ASSERT_NOT_NULL(upgrade_request);
-    ASSERT_SUCCESS(aws_http_request_set_method(upgrade_request, aws_byte_cursor_from_c_str("GET")));
+    ASSERT_SUCCESS(aws_http_request_set_method(upgrade_request, aws_http_method_get));
     ASSERT_SUCCESS(aws_http_request_set_path(upgrade_request, aws_byte_cursor_from_c_str("/")));
     ASSERT_SUCCESS(aws_http_request_add_header_array(upgrade_request, headers, AWS_ARRAY_SIZE(headers)));
 

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -18,6 +18,7 @@
 
 #include <aws/common/uuid.h>
 #include <aws/io/logging.h>
+#include <aws/io/stream.h>
 #include <aws/testing/io_testing_channel.h>
 
 #if _MSC_VER
@@ -27,6 +28,15 @@
 #define H1_CLIENT_TEST_CASE(NAME)                                                                                      \
     AWS_TEST_CASE(NAME, s_test_##NAME);                                                                                \
     static int s_test_##NAME(struct aws_allocator *allocator, void *ctx)
+
+static struct aws_http_request *s_new_default_get_request(struct aws_allocator *allocator) {
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    AWS_FATAL_ASSERT(request);
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_http_request_set_method(request, aws_byte_cursor_from_c_str("GET")));
+    AWS_FATAL_ASSERT(AWS_OP_SUCCESS == aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/")));
+
+    return request;
+}
 
 struct tester {
     struct aws_allocator *alloc;
@@ -144,8 +154,7 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_1liner) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NOT_NULL(stream);
 
@@ -157,6 +166,7 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_1liner) {
     ASSERT_SUCCESS(s_check_written_message(&tester, expected));
 
     /* clean up */
+    aws_http_request_destroy(opt.request);
     aws_http_stream_release(stream);
 
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
@@ -171,21 +181,22 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_headers) {
     /* send request */
     struct aws_http_header headers[] = {
         {
-            .name = aws_byte_cursor_from_c_str("Host"),
-            .value = aws_byte_cursor_from_c_str("example.com"),
+            .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Host"),
+            .value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("example.com"),
         },
         {
-            .name = aws_byte_cursor_from_c_str("Accept"),
-            .value = aws_byte_cursor_from_c_str("*/*"),
+            .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Accept"),
+            .value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("*/*"),
         },
     };
 
+    struct aws_http_request *request = s_new_default_get_request(allocator);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers)));
+
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
-    opt.header_array = headers;
-    opt.num_headers = AWS_ARRAY_SIZE(headers);
+    opt.request = request;
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NOT_NULL(stream);
 
@@ -199,31 +210,11 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_headers) {
     ASSERT_SUCCESS(s_check_written_message(&tester, expected));
 
     /* clean up */
+    aws_http_request_destroy(request);
     aws_http_stream_release(stream);
 
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
     return AWS_OP_SUCCESS;
-}
-
-struct simple_body_sender {
-    struct aws_byte_cursor src;
-    size_t progress;
-};
-
-static enum aws_http_outgoing_body_state s_simple_send_body(
-    struct aws_http_stream *stream,
-    struct aws_byte_buf *buf,
-    void *user_data) {
-
-    (void)stream;
-    struct simple_body_sender *data = user_data;
-    size_t remaining = data->src.len - data->progress;
-    size_t available = buf->capacity - buf->len;
-    size_t writing = remaining < available ? remaining : available;
-    aws_byte_buf_write(buf, data->src.ptr + data->progress, writing);
-    data->progress += writing;
-
-    return (writing == remaining) ? AWS_HTTP_OUTGOING_BODY_DONE : AWS_HTTP_OUTGOING_BODY_IN_PROGRESS;
 }
 
 H1_CLIENT_TEST_CASE(h1_client_request_send_body) {
@@ -232,25 +223,26 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_body) {
     ASSERT_SUCCESS(s_tester_init(&tester, allocator));
 
     /* send request */
-    struct simple_body_sender body_sender = {
-        .src = aws_byte_cursor_from_c_str("write more tests"),
-    };
+    static const struct aws_byte_cursor body = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("write more tests");
+    struct aws_input_stream *body_stream = aws_input_stream_new_from_cursor(allocator, &body);
 
     struct aws_http_header headers[] = {
         {
-            .name = aws_byte_cursor_from_c_str("Content-Length"),
-            .value = aws_byte_cursor_from_c_str("16"),
+            .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Content-Length"),
+            .value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("16"),
         },
     };
 
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("PUT")));
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/plan.txt")));
+    aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers));
+    aws_http_request_set_body_stream(request, body_stream);
+
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("PUT");
-    opt.uri = aws_byte_cursor_from_c_str("/plan.txt");
-    opt.header_array = headers;
-    opt.num_headers = AWS_ARRAY_SIZE(headers);
-    opt.user_data = &body_sender;
-    opt.stream_outgoing_body = s_simple_send_body;
+    opt.request = request;
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NOT_NULL(stream);
 
@@ -264,6 +256,8 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_body) {
     ASSERT_SUCCESS(s_check_written_message(&tester, expected));
 
     /* clean up */
+    aws_input_stream_destroy(body_stream);
+    aws_http_request_destroy(request);
     aws_http_stream_release(stream);
 
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
@@ -338,9 +332,8 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_large_body) {
         aws_byte_buf_write_be32(&body_buf, (uint32_t)r);
     }
 
-    struct simple_body_sender body_sender = {
-        .src = aws_byte_cursor_from_buf(&body_buf),
-    };
+    const struct aws_byte_cursor body = aws_byte_cursor_from_buf(&body_buf);
+    struct aws_input_stream *body_stream = aws_input_stream_new_from_cursor(allocator, &body);
 
     char content_length_value[100];
     snprintf(content_length_value, sizeof(content_length_value), "%zu", body_len);
@@ -351,14 +344,16 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_large_body) {
         },
     };
 
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("PUT")));
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/large.txt")));
+    aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers));
+    aws_http_request_set_body_stream(request, body_stream);
+
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("PUT");
-    opt.uri = aws_byte_cursor_from_c_str("/large.txt");
-    opt.header_array = headers;
-    opt.num_headers = AWS_ARRAY_SIZE(headers);
-    opt.user_data = &body_sender;
-    opt.stream_outgoing_body = s_simple_send_body;
+    opt.request = request;
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NOT_NULL(stream);
 
@@ -380,6 +375,8 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_large_body) {
     ASSERT_TRUE(num_io_messages > 1);
 
     /* clean up */
+    aws_input_stream_destroy(body_stream);
+    aws_http_request_destroy(request);
     aws_http_stream_release(stream);
 
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
@@ -425,13 +422,13 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_large_head) {
 
     ASSERT_TRUE(aws_byte_buf_write(&expected, (uint8_t *)"\r\n", 2));
 
+    struct aws_http_request *request = s_new_default_get_request(allocator);
+    ASSERT_SUCCESS(aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers)));
+
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
-    opt.header_array = headers;
-    opt.num_headers = num_headers;
+    opt.request = request;
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NOT_NULL(stream);
 
@@ -442,6 +439,7 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_large_head) {
     ASSERT_TRUE(num_io_messages > 1);
 
     /* clean up */
+    aws_http_request_destroy(request);
     aws_http_stream_release(stream);
 
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
@@ -459,8 +457,7 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_multiple_in_1_io_message) {
     /* send requests */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct aws_http_stream *streams[3];
     size_t num_streams = AWS_ARRAY_SIZE(streams);
@@ -470,6 +467,9 @@ H1_CLIENT_TEST_CASE(h1_client_request_send_multiple_in_1_io_message) {
     }
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* check result */
     const char *expected = "GET / HTTP/1.1\r\n"
@@ -695,13 +695,15 @@ H1_CLIENT_TEST_CASE(h1_client_response_get_1liner) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     ASSERT_SUCCESS(s_send_response_str(&tester, "HTTP/1.1 204 No Content\r\n\r\n"));
@@ -740,13 +742,15 @@ H1_CLIENT_TEST_CASE(h1_client_response_get_headers) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     ASSERT_SUCCESS(s_send_response_str(
@@ -782,13 +786,15 @@ H1_CLIENT_TEST_CASE(h1_client_response_get_body) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     ASSERT_SUCCESS(s_send_response_str(
@@ -824,13 +830,15 @@ H1_CLIENT_TEST_CASE(h1_client_response_get_1_from_multiple_io_messages) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response with each byte in its own aws_io_message */
     const char *response_str = "HTTP/1.1 200 OK\r\n"
@@ -868,14 +876,16 @@ H1_CLIENT_TEST_CASE(h1_client_response_get_multiple_from_1_io_message) {
     /* send requests */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester responses[3];
     for (size_t i = 0; i < AWS_ARRAY_SIZE(responses); ++i) {
         ASSERT_SUCCESS(s_response_tester_init(&responses[i], allocator, &opt));
     }
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send all responses in a single aws_io_message  */
     ASSERT_SUCCESS(s_send_response_str(
@@ -910,13 +920,15 @@ H1_CLIENT_TEST_CASE(h1_client_response_with_bad_data_shuts_down_connection) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     ASSERT_SUCCESS(s_send_response_str_ignore_errors(&tester, "Mmmm garbage data\r\n\r\n"));
@@ -943,12 +955,14 @@ H1_CLIENT_TEST_CASE(h1_client_response_with_too_much_data_shuts_down_connection)
     /* send 1 request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send 2 responses in a single aws_io_message. */
     ASSERT_SUCCESS(s_send_response_str_ignore_errors(
@@ -977,20 +991,16 @@ H1_CLIENT_TEST_CASE(h1_client_response_with_too_much_data_shuts_down_connection)
 }
 
 struct slow_body_sender {
+    struct aws_stream_status status;
     struct aws_byte_cursor cursor;
     size_t delay_ticks;    /* Don't send anything the first N ticks */
     size_t bytes_per_tick; /* Don't send more than N bytes per tick */
 };
 
-static enum aws_http_outgoing_body_state s_slow_send_body(
-    struct aws_http_stream *stream,
-    struct aws_byte_buf *buf,
-    void *user_data) {
+int s_slow_stream_read(struct aws_input_stream *stream, struct aws_byte_buf *dest, size_t *amount_read) {
+    struct slow_body_sender *sender = stream->impl;
 
-    (void)stream;
-    struct response_tester *response = user_data;
-    struct slow_body_sender *sender = response->specific_test_data;
-    size_t dst_available = buf->capacity - buf->len;
+    size_t dst_available = dest->capacity - dest->len;
     size_t writing = 0;
     if (sender->delay_ticks > 0) {
         sender->delay_ticks--;
@@ -1006,11 +1016,36 @@ static enum aws_http_outgoing_body_state s_slow_send_body(
         }
     }
 
-    aws_byte_buf_write(buf, sender->cursor.ptr, writing);
+    aws_byte_buf_write(dest, sender->cursor.ptr, writing);
     aws_byte_cursor_advance(&sender->cursor, writing);
 
-    return (sender->cursor.len == 0) ? AWS_HTTP_OUTGOING_BODY_DONE : AWS_HTTP_OUTGOING_BODY_IN_PROGRESS;
+    if (sender->cursor.len == 0) {
+        sender->status.is_end_of_stream = true;
+    }
+
+    return AWS_OP_SUCCESS;
 }
+int s_slow_stream_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
+    struct slow_body_sender *sender = stream->impl;
+    *status = sender->status;
+    return AWS_OP_SUCCESS;
+}
+int s_slow_stream_get_length(struct aws_input_stream *stream, int64_t *out_length) {
+    struct slow_body_sender *sender = stream->impl;
+    *out_length = sender->cursor.len;
+    return AWS_OP_SUCCESS;
+}
+void s_slow_stream_clean_up(struct aws_input_stream *stream) {
+    (void)stream;
+}
+
+static struct aws_input_stream_vtable s_slow_stream_vtable = {
+    .seek = NULL,
+    .read = s_slow_stream_read,
+    .get_status = s_slow_stream_get_status,
+    .get_length = s_slow_stream_get_length,
+    .clean_up = s_slow_stream_clean_up,
+};
 
 /* It should be fine to receive a response before the request has finished sending */
 H1_CLIENT_TEST_CASE(h1_client_response_arrives_before_request_done_sending_is_ok) {
@@ -1020,9 +1055,19 @@ H1_CLIENT_TEST_CASE(h1_client_response_arrives_before_request_done_sending_is_ok
 
     /* set up request whose body won't send immediately */
     struct slow_body_sender body_sender = {
-        .cursor = aws_byte_cursor_from_c_str("write more tests"),
+        .status =
+            {
+                .is_end_of_stream = false,
+                .is_valid = true,
+            },
+        .cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("write more tests"),
         .delay_ticks = 5,
         .bytes_per_tick = 1,
+    };
+    struct aws_input_stream body_stream = {
+        .allocator = allocator,
+        .impl = &body_sender,
+        .vtable = &s_slow_stream_vtable,
     };
 
     struct aws_http_header headers[] = {
@@ -1032,19 +1077,25 @@ H1_CLIENT_TEST_CASE(h1_client_response_arrives_before_request_done_sending_is_ok
         },
     };
 
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("PUT")));
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/plan.txt")));
+    ASSERT_SUCCESS(aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers)));
+    aws_http_request_set_body_stream(request, &body_stream);
+
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("PUT");
-    opt.uri = aws_byte_cursor_from_c_str("/plan.txt");
-    opt.header_array = headers;
-    opt.num_headers = AWS_ARRAY_SIZE(headers);
-    opt.stream_outgoing_body = s_slow_send_body;
+    opt.request = request;
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init_ex(&response, allocator, &opt, &body_sender));
 
     /* send head of request */
     testing_channel_run_currently_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     ASSERT_SUCCESS(s_send_response_str(&tester, "HTTP/1.1 200 OK\r\n\r\n"));
@@ -1103,13 +1154,15 @@ H1_CLIENT_TEST_CASE(h1_client_window_reopens_by_default) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     const char *response_str = "HTTP/1.1 200 OK\r\n"
@@ -1139,14 +1192,16 @@ H1_CLIENT_TEST_CASE(h1_client_window_shrinks_if_user_says_so) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
     response.stop_auto_window_update = true;
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     const char *response_str = "HTTP/1.1 200 OK\r\n"
@@ -1176,14 +1231,16 @@ static int s_window_update(struct aws_allocator *allocator, bool on_thread) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     ASSERT_SUCCESS(s_response_tester_init(&response, allocator, &opt));
     response.stop_auto_window_update = true;
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     const char *response_str = "HTTP/1.1 200 OK\r\n"
@@ -1243,14 +1300,16 @@ H1_CLIENT_TEST_CASE(h1_client_request_cancelled_by_channel_shutdown) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
     opt.user_data = &completion_error_code;
     opt.on_complete = s_on_complete;
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NOT_NULL(stream);
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* shutdown channel before request completes */
     aws_channel_shutdown(tester.testing_channel.channel, AWS_ERROR_SUCCESS);
@@ -1278,8 +1337,7 @@ H1_CLIENT_TEST_CASE(h1_client_multiple_requests_cancelled_by_channel_shutdown) {
 
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
     opt.on_complete = s_on_complete;
 
     for (int i = 0; i < 2; ++i) {
@@ -1299,6 +1357,9 @@ H1_CLIENT_TEST_CASE(h1_client_multiple_requests_cancelled_by_channel_shutdown) {
     /* shutdown channel */
     aws_channel_shutdown(tester.testing_channel.channel, AWS_ERROR_SUCCESS);
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* check results */
     for (int i = 0; i < 3; ++i) {
@@ -1320,12 +1381,12 @@ H1_CLIENT_TEST_CASE(h1_client_new_request_fails_if_channel_shut_down) {
     /* send request */
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("GET");
-    opt.uri = aws_byte_cursor_from_c_str("/");
+    opt.request = s_new_default_get_request(allocator);
     struct aws_http_stream *stream = aws_http_stream_new_client_request(&opt);
     ASSERT_NULL(stream);
     ASSERT_INT_EQUALS(aws_last_error(), AWS_ERROR_HTTP_CONNECTION_CLOSED);
 
+    aws_http_request_destroy(opt.request);
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
     return AWS_OP_SUCCESS;
 }
@@ -1343,6 +1404,7 @@ struct close_from_callback_tester {
     enum request_callback close_at;
     int callback_counts[REQUEST_CALLBACK_COUNT];
     bool is_closed;
+    struct aws_stream_status status;
 };
 
 static void s_close_from_callback_common(
@@ -1368,22 +1430,44 @@ static void s_close_from_callback_common(
     }
 }
 
-static enum aws_http_outgoing_body_state s_close_from_outgoing_body(
-    struct aws_http_stream *stream,
-    struct aws_byte_buf *buf,
-    void *user_data) {
+static int s_close_from_outgoing_body_read(
+    struct aws_input_stream *stream,
+    struct aws_byte_buf *dest,
+    size_t *amount_read) {
 
-    (void)buf;
-    s_close_from_callback_common(stream, user_data, REQUEST_CALLBACK_OUTGOING_BODY);
+    (void)dest;
+
+    struct close_from_callback_tester *close_tester = stream->impl;
+
+    *amount_read = 0;
+
+    close_tester->callback_counts[REQUEST_CALLBACK_OUTGOING_BODY]++;
 
     /* If we're closing from this function, try and keep going. It's a failure if we're invoked again. */
-    struct close_from_callback_tester *close_tester = user_data;
     if (close_tester->close_at == REQUEST_CALLBACK_OUTGOING_BODY) {
-        return AWS_HTTP_OUTGOING_BODY_IN_PROGRESS;
+        close_tester->is_closed = true;
+        return AWS_OP_ERR;
     } else {
-        return AWS_HTTP_OUTGOING_BODY_DONE;
+        close_tester->status.is_end_of_stream = true;
+        return AWS_OP_SUCCESS;
     }
 }
+static int s_close_from_outgoing_body_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
+    struct close_from_callback_tester *close_tester = stream->impl;
+    *status = close_tester->status;
+    return AWS_OP_SUCCESS;
+}
+static void s_close_from_outgoing_body_clean_up(struct aws_input_stream *stream) {
+    (void)stream;
+}
+
+static struct aws_input_stream_vtable s_close_from_outgoing_body_vtable = {
+    .seek = NULL,
+    .read = s_close_from_outgoing_body_read,
+    .get_status = s_close_from_outgoing_body_get_status,
+    .get_length = NULL,
+    .clean_up = s_close_from_outgoing_body_clean_up,
+};
 
 static void s_close_from_incoming_headers(
     struct aws_http_stream *stream,
@@ -1424,6 +1508,15 @@ static int s_test_close_from_callback(struct aws_allocator *allocator, enum requ
 
     struct close_from_callback_tester close_tester = {
         .close_at = close_at,
+        .status = {
+            .is_valid = true,
+            .is_end_of_stream = false,
+        }
+    };
+    struct aws_input_stream close_from_outgoing_body_stream = {
+        .allocator = allocator,
+        .impl = &close_tester,
+        .vtable = &s_close_from_outgoing_body_vtable,
     };
 
     /* send request */
@@ -1434,13 +1527,16 @@ static int s_test_close_from_callback(struct aws_allocator *allocator, enum requ
         },
     };
 
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("POST")));
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/")));
+    ASSERT_SUCCESS(aws_http_request_add_header_array(request, headers, AWS_ARRAY_SIZE(headers)));
+    aws_http_request_set_body_stream(request, &close_from_outgoing_body_stream);
+
     struct aws_http_request_options opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     opt.client_connection = tester.connection;
-    opt.method = aws_byte_cursor_from_c_str("POST");
-    opt.uri = aws_byte_cursor_from_c_str("/");
-    opt.header_array = headers;
-    opt.num_headers = AWS_ARRAY_SIZE(headers);
-    opt.stream_outgoing_body = s_close_from_outgoing_body;
+    opt.request = request;
     opt.on_response_headers = s_close_from_incoming_headers;
     opt.on_response_header_block_done = s_close_from_incoming_headers_done;
     opt.on_response_body = s_close_from_incoming_body;
@@ -1451,6 +1547,9 @@ static int s_test_close_from_callback(struct aws_allocator *allocator, enum requ
     ASSERT_NOT_NULL(stream);
 
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(opt.request);
 
     /* send response */
     ASSERT_SUCCESS(s_send_response_str_ignore_errors(
@@ -1601,18 +1700,24 @@ static int s_switch_protocols(struct protocol_switcher *switcher) {
         },
     };
 
+    struct aws_http_request *request = aws_http_request_new(switcher->tester->alloc);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("GET")));
+    ASSERT_SUCCESS(aws_http_request_set_path(request, aws_byte_cursor_from_c_str("/")));
+    ASSERT_SUCCESS(aws_http_request_add_header_array(request, request_headers, AWS_ARRAY_SIZE(request_headers)));
+
     struct aws_http_request_options upgrade_request = AWS_HTTP_REQUEST_OPTIONS_INIT;
     upgrade_request.client_connection = switcher->tester->connection;
-    upgrade_request.method = aws_byte_cursor_from_c_str("GET");
-    upgrade_request.uri = aws_byte_cursor_from_c_str("/");
-    upgrade_request.header_array = request_headers;
-    upgrade_request.num_headers = AWS_ARRAY_SIZE(request_headers);
+    upgrade_request.request = request;
     upgrade_request.user_data = switcher;
     upgrade_request.on_complete = s_switch_protocols_on_stream_complete;
 
     struct aws_http_stream *upgrade_stream = aws_http_stream_new_client_request(&upgrade_request);
     ASSERT_NOT_NULL(upgrade_stream);
     testing_channel_drain_queued_tasks(&switcher->tester->testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(upgrade_request.request);
 
     /* clear all messages written thus far to the testing-channel */
     while (!aws_linked_list_empty(testing_channel_get_written_message_queue(&switcher->tester->testing_channel))) {
@@ -1847,12 +1952,15 @@ H1_CLIENT_TEST_CASE(h1_client_switching_protocols_fails_pending_requests) {
         },
     };
 
+    struct aws_http_request *upgrade_request = aws_http_request_new(allocator);
+    ASSERT_NOT_NULL(upgrade_request);
+    ASSERT_SUCCESS(aws_http_request_set_method(upgrade_request, aws_byte_cursor_from_c_str("GET")));
+    ASSERT_SUCCESS(aws_http_request_set_path(upgrade_request, aws_byte_cursor_from_c_str("/")));
+    ASSERT_SUCCESS(aws_http_request_add_header_array(upgrade_request, headers, AWS_ARRAY_SIZE(headers)));
+
     struct aws_http_request_options upgrade_req = AWS_HTTP_REQUEST_OPTIONS_INIT;
     upgrade_req.client_connection = tester.connection;
-    upgrade_req.method = aws_byte_cursor_from_c_str("GET");
-    upgrade_req.uri = aws_byte_cursor_from_c_str("/chat");
-    upgrade_req.header_array = headers;
-    upgrade_req.num_headers = AWS_ARRAY_SIZE(headers);
+    upgrade_req.request = upgrade_request;
 
     struct response_tester upgrade_response;
     ASSERT_SUCCESS(s_response_tester_init(&upgrade_response, allocator, &upgrade_req));
@@ -1860,14 +1968,17 @@ H1_CLIENT_TEST_CASE(h1_client_switching_protocols_fails_pending_requests) {
     /* queue another request behind it */
     struct aws_http_request_options next_req = AWS_HTTP_REQUEST_OPTIONS_INIT;
     next_req.client_connection = tester.connection;
-    next_req.method = aws_byte_cursor_from_c_str("GET");
-    next_req.uri = aws_byte_cursor_from_c_str("/");
+    next_req.request = s_new_default_get_request(allocator);
 
     struct response_tester next_response;
     ASSERT_SUCCESS(s_response_tester_init(&next_response, allocator, &next_req));
 
     /* send upgrade response */
     testing_channel_drain_queued_tasks(&tester.testing_channel);
+
+    /* Ensure the request can be destroyed after request is sent */
+    aws_http_request_destroy(upgrade_request);
+    aws_http_request_destroy(next_req.request);
 
     ASSERT_SUCCESS(s_send_response_str(
         &tester,
@@ -1906,8 +2017,7 @@ H1_CLIENT_TEST_CASE(h1_client_switching_protocols_fails_subsequent_requests) {
     /* Attempting to send a request after this should fail. */
     struct aws_http_request_options request_opt = AWS_HTTP_REQUEST_OPTIONS_INIT;
     request_opt.client_connection = tester.connection;
-    request_opt.method = aws_byte_cursor_from_c_str("GET");
-    request_opt.uri = aws_byte_cursor_from_c_str("/");
+    request_opt.request = s_new_default_get_request(allocator);
 
     struct response_tester response;
     int err = s_response_tester_init(&response, allocator, &request_opt);
@@ -1920,6 +2030,7 @@ H1_CLIENT_TEST_CASE(h1_client_switching_protocols_fails_subsequent_requests) {
     }
 
     /* clean up */
+    aws_http_request_destroy(request_opt.request);
     ASSERT_SUCCESS(s_response_tester_clean_up(&response));
     ASSERT_SUCCESS(s_tester_clean_up(&tester));
     return AWS_OP_SUCCESS;

--- a/tests/test_h1_decoder.c
+++ b/tests/test_h1_decoder.c
@@ -169,7 +169,7 @@ static int s_h1_test_get_request(struct aws_allocator *allocator, void *ctx) {
     ASSERT_SUCCESS(aws_h1_decode(decoder, &msg));
     ASSERT_INT_EQUALS(AWS_HTTP_METHOD_HEAD, request_data.method_enum);
 
-    ASSERT_TRUE(aws_byte_cursor_eq_c_str(&request_data.method_str, "HEAD"));
+    ASSERT_TRUE(aws_byte_cursor_eq(&request_data.method_str, &aws_http_method_head));
 
     ASSERT_TRUE(aws_byte_cursor_eq_c_str(&request_data.uri, "/"));
 

--- a/tests/test_request.c
+++ b/tests/test_request.c
@@ -76,11 +76,10 @@ TEST_CASE(request_method) {
 
     /* Mutilate the original string to be sure request wasn't referencing its memory */
     method1[0] = 'B';
-    struct aws_byte_cursor method1_repro = aws_byte_cursor_from_c_str("GET");
-    ASSERT_TRUE(aws_byte_cursor_eq(&method1_repro, &get));
+    ASSERT_TRUE(aws_byte_cursor_eq(&aws_http_method_get, &get));
 
     /* Set a new method */
-    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_byte_cursor_from_c_str("POST")));
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_http_method_post));
     ASSERT_SUCCESS(aws_http_request_get_method(request, &get));
     ASSERT_TRUE(aws_byte_cursor_eq_c_str(&get, "POST"));
 

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -207,6 +207,7 @@ static int s_test_tls_download_medium_file(struct aws_allocator *allocator, void
 
     ASSERT_INT_EQUALS(14428801, test.body_size);
 
+    aws_http_request_destroy(request);
     aws_http_stream_release(test.stream);
     test.stream = NULL;
 

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -182,15 +182,19 @@ static int s_test_tls_download_medium_file(struct aws_allocator *allocator, void
     ASSERT_INT_EQUALS(0, test.wait_result);
     ASSERT_NOT_NULL(test.client_connection);
 
-    struct aws_http_header headers[] = {
-        {.name = aws_byte_cursor_from_c_str("Host"), .value = *aws_uri_host_name(&uri)}};
+    struct aws_http_request *request = aws_http_request_new(allocator);
+    aws_http_request_set_method(request, aws_byte_cursor_from_c_str("GET"));
+    aws_http_request_set_path(request, *aws_uri_path_and_query(&uri));
+
+    struct aws_http_header header_host = {
+        .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Host"),
+        .value = *aws_uri_host_name(&uri),
+    };
+    aws_http_request_add_header(request, header_host);
 
     struct aws_http_request_options req_options = AWS_HTTP_REQUEST_OPTIONS_INIT;
     req_options.client_connection = test.client_connection;
-    req_options.method = aws_byte_cursor_from_c_str("GET");
-    req_options.uri = *aws_uri_path_and_query(&uri);
-    req_options.header_array = headers;
-    req_options.num_headers = AWS_ARRAY_SIZE(headers);
+    req_options.request = request;
     req_options.on_response_headers = s_on_stream_headers;
     req_options.on_response_body = s_on_stream_body;
     req_options.on_complete = s_on_stream_complete;

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -183,14 +183,15 @@ static int s_test_tls_download_medium_file(struct aws_allocator *allocator, void
     ASSERT_NOT_NULL(test.client_connection);
 
     struct aws_http_request *request = aws_http_request_new(allocator);
-    aws_http_request_set_method(request, aws_http_method_get);
-    aws_http_request_set_path(request, *aws_uri_path_and_query(&uri));
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_request_set_method(request, aws_http_method_get));
+    ASSERT_SUCCESS(aws_http_request_set_path(request, *aws_uri_path_and_query(&uri)));
 
     struct aws_http_header header_host = {
         .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Host"),
         .value = *aws_uri_host_name(&uri),
     };
-    aws_http_request_add_header(request, header_host);
+    ASSERT_SUCCESS(aws_http_request_add_header(request, header_host));
 
     struct aws_http_request_options req_options = AWS_HTTP_REQUEST_OPTIONS_INIT;
     req_options.client_connection = test.client_connection;

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -183,7 +183,7 @@ static int s_test_tls_download_medium_file(struct aws_allocator *allocator, void
     ASSERT_NOT_NULL(test.client_connection);
 
     struct aws_http_request *request = aws_http_request_new(allocator);
-    aws_http_request_set_method(request, aws_byte_cursor_from_c_str("GET"));
+    aws_http_request_set_method(request, aws_http_method_get);
     aws_http_request_set_path(request, *aws_uri_path_and_query(&uri));
 
     struct aws_http_header header_host = {

--- a/tests/test_websocket_bootstrap.c
+++ b/tests/test_websocket_bootstrap.c
@@ -190,9 +190,7 @@ static bool s_headers_eq(
     return true;
 }
 
-static bool s_request_eq(
-    const struct aws_http_request *request_a,
-    const struct aws_http_request *request_b) {
+static bool s_request_eq(const struct aws_http_request *request_a, const struct aws_http_request *request_b) {
 
     const size_t num_headers_a = aws_http_request_get_header_count(request_a);
     const size_t num_headers_b = aws_http_request_get_header_count(request_b);
@@ -202,8 +200,8 @@ static bool s_request_eq(
     }
 
     for (size_t a_i = 0; a_i < num_headers_a; ++a_i) {
-            struct aws_http_header a;
-            aws_http_request_get_header(request_a, &a, a_i);
+        struct aws_http_header a;
+        aws_http_request_get_header(request_a, &a, a_i);
 
         bool found_match = false;
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
