### PR TITLE
H1B: Use response class instead of response_options

### DIFF
--- a/include/aws/http/private/connection_impl.h
+++ b/include/aws/http/private/connection_impl.h
@@ -24,16 +24,16 @@
 #include <aws/common/atomics.h>
 #include <aws/io/channel.h>
 
+struct aws_http_message;
 struct aws_http_request_options;
 struct aws_http_request_handler_options;
 struct aws_http_stream;
-struct aws_http_response_options;
 
 struct aws_http_connection_vtable {
     struct aws_channel_handler_vtable channel_handler_vtable;
 
     struct aws_http_stream *(*new_client_request_stream)(const struct aws_http_request_options *options);
-    int (*stream_send_response)(struct aws_http_stream *stream, const struct aws_http_response_options *options);
+    int (*stream_send_response)(struct aws_http_stream *stream, struct aws_http_message *response);
     void (*close)(struct aws_http_connection *connection);
     bool (*is_open)(const struct aws_http_connection *connection);
     void (*update_window)(struct aws_http_connection *connection, size_t increment_size);

--- a/include/aws/http/private/h1_encoder.h
+++ b/include/aws/http/private/h1_encoder.h
@@ -56,7 +56,7 @@ int aws_h1_encoder_message_init_from_request(
 int aws_h1_encoder_message_init_from_response(
     struct aws_h1_encoder_message *message,
     struct aws_allocator *allocator,
-    const struct aws_http_response_options *response);
+    const struct aws_http_message *response);
 
 AWS_HTTP_API
 void aws_h1_encoder_message_clean_up(struct aws_h1_encoder_message *message);

--- a/include/aws/http/private/request_response_impl.h
+++ b/include/aws/http/private/request_response_impl.h
@@ -38,7 +38,6 @@ struct aws_http_stream {
     const struct aws_http_stream_vtable *vtable;
     struct aws_allocator *alloc;
     struct aws_http_connection *owning_connection;
-    struct aws_input_stream *outgoing_body;
 
     bool manual_window_management;
 
@@ -52,7 +51,6 @@ struct aws_http_stream {
 
     union {
         struct aws_http_stream_client_data {
-            struct aws_http_message *request;
             int response_status;
         } client;
         struct aws_http_stream_server_data {

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -238,19 +238,6 @@ struct aws_http_request_handler_options {
 #define AWS_HTTP_REQUEST_HANDLER_OPTIONS_INIT                                                                          \
     { .self_size = sizeof(struct aws_http_request_handler_options), }
 
-struct aws_http_response_options {
-    /* Set to sizeof() this struct, used for versioning. */
-    size_t self_size;
-
-    int status;
-    const struct aws_http_header *header_array;
-    size_t num_headers;
-    struct aws_input_stream *body_stream;
-};
-
-#define AWS_HTTP_RESPONSE_OPTIONS_INIT                                                                                 \
-    { .self_size = sizeof(struct aws_http_response_options), }
-
 AWS_EXTERN_C_BEGIN
 
 /**
@@ -437,9 +424,12 @@ int aws_http_stream_get_incoming_request_method(
 AWS_HTTP_API
 int aws_http_stream_get_incoming_request_uri(const struct aws_http_stream *stream, struct aws_byte_cursor *out_uri);
 
-/* only callable from "request handler" streams */
+/**
+ * Send response (only callable from "request handler" streams)
+ * The response object must stay alive at least until the stream's on_complete is called.
+ */
 AWS_HTTP_API
-int aws_http_stream_send_response(struct aws_http_stream *stream, const struct aws_http_response_options *options);
+int aws_http_stream_send_response(struct aws_http_stream *stream, struct aws_http_message *response);
 
 /**
  * Manually issue a window update.

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -61,7 +61,7 @@ static size_t s_handler_initial_window_size(struct aws_channel_handler *handler)
 static size_t s_handler_message_overhead(struct aws_channel_handler *handler);
 static void s_handler_destroy(struct aws_channel_handler *handler);
 static struct aws_http_stream *s_new_client_request_stream(const struct aws_http_request_options *options);
-static int s_stream_send_response(struct aws_http_stream *stream, const struct aws_http_response_options *options);
+static int s_stream_send_response(struct aws_http_stream *stream, struct aws_http_message *response);
 static void s_connection_close(struct aws_http_connection *connection_base);
 static bool s_connection_is_open(const struct aws_http_connection *connection_base);
 static void s_connection_update_window(struct aws_http_connection *connection_base, size_t increment_size);
@@ -253,9 +253,9 @@ static bool s_connection_is_open(const struct aws_http_connection *connection_ba
     return !is_shutting_down;
 }
 
-static int s_stream_send_response(struct aws_http_stream *stream, const struct aws_http_response_options *options) {
+static int s_stream_send_response(struct aws_http_stream *stream, struct aws_http_message *response) {
     AWS_PRECONDITION(stream);
-    AWS_PRECONDITION(options);
+    AWS_PRECONDITION(response);
 
     int err;
     int send_err = AWS_ERROR_SUCCESS;
@@ -265,7 +265,7 @@ static int s_stream_send_response(struct aws_http_stream *stream, const struct a
     /* Validate the response and cache info that encoder will eventually need.
      * The encoder_message object will be moved into the stream later while holding the lock */
     struct aws_h1_encoder_message encoder_message;
-    err = aws_h1_encoder_message_init_from_response(&encoder_message, stream->alloc, options);
+    err = aws_h1_encoder_message_init_from_response(&encoder_message, stream->alloc, response);
     if (err) {
         send_err = aws_last_error();
         goto response_error;

--- a/source/h1_encoder.c
+++ b/source/h1_encoder.c
@@ -170,44 +170,34 @@ error:
 int aws_h1_encoder_message_init_from_response(
     struct aws_h1_encoder_message *message,
     struct aws_allocator *allocator,
-    const struct aws_http_response_options *response) {
+    const struct aws_http_message *response) {
 
     AWS_ZERO_STRUCT(*message);
 
-    /* Until we write the aws_http_response class, interact with header functions via an aws_http_request */
-    struct aws_http_message *tmp_request = aws_http_message_new_request(allocator);
-    if (!tmp_request) {
-        goto error;
-    }
-    aws_http_message_set_body_stream(tmp_request, response->body_stream);
-    for (size_t i = 0; i < response->num_headers; ++i) {
-        if (aws_http_message_add_header(tmp_request, response->header_array[i])) {
-            goto error;
-        }
-    }
-
-    message->body = response->body_stream;
+    message->body = aws_http_message_get_body_stream(response);
 
     struct aws_byte_cursor version = aws_http_version_to_str(AWS_HTTP_VERSION_1_1);
 
-    /* Status code must fit in 3 digits */
-    if (response->status < 0 || response->status > 999) {
-        aws_raise_error(AWS_ERROR_HTTP_INVALID_STATUS_CODE);
-        goto error;
+    int status_int;
+    int err = aws_http_message_get_response_status(response, &status_int);
+    if (err) {
+        return aws_raise_error(AWS_ERROR_HTTP_INVALID_STATUS_CODE);
     }
 
+    /* Status code must fit in 3 digits */
+    AWS_ASSERT(status_int >= 0 && status_int <= 999); /* aws_http_message should have already checked this */
     char status_code_str[4] = "XXX";
-    snprintf(status_code_str, sizeof(status_code_str), "%03d", response->status);
+    snprintf(status_code_str, sizeof(status_code_str), "%03d", status_int);
     struct aws_byte_cursor status_code = aws_byte_cursor_from_c_str(status_code_str);
 
-    struct aws_byte_cursor status_text = aws_byte_cursor_from_c_str(aws_http_status_text(response->status));
+    struct aws_byte_cursor status_text = aws_byte_cursor_from_c_str(aws_http_status_text(status_int));
 
     /**
      * Calculate total size needed for outgoing_head_buffer, then write to buffer.
      */
 
     size_t header_lines_len;
-    int err = s_scan_outgoing_headers(tmp_request, &header_lines_len);
+    err = s_scan_outgoing_headers(response, &header_lines_len);
     if (err) {
         goto error;
     }
@@ -243,7 +233,7 @@ int aws_h1_encoder_message_init_from_response(
     wrote_all &= aws_byte_buf_write_u8(&message->outgoing_head_buf, '\r');
     wrote_all &= aws_byte_buf_write_u8(&message->outgoing_head_buf, '\n');
 
-    s_write_headers(&message->outgoing_head_buf, tmp_request);
+    s_write_headers(&message->outgoing_head_buf, response);
 
     wrote_all &= aws_byte_buf_write_u8(&message->outgoing_head_buf, '\r');
     wrote_all &= aws_byte_buf_write_u8(&message->outgoing_head_buf, '\n');
@@ -251,11 +241,9 @@ int aws_h1_encoder_message_init_from_response(
     AWS_ASSERT(wrote_all);
 
     /* Success! */
-    aws_http_message_destroy(tmp_request);
     return AWS_OP_SUCCESS;
 
 error:
-    aws_http_message_destroy(tmp_request);
     aws_h1_encoder_message_clean_up(message);
     return AWS_OP_ERR;
 }

--- a/source/h1_stream.c
+++ b/source/h1_stream.c
@@ -75,7 +75,6 @@ struct aws_h1_stream *aws_h1_stream_new_request(const struct aws_http_request_op
     stream->base.on_complete = options->on_complete;
     stream->base.client_data = &stream->base.client_or_server_data.client;
     stream->base.client_data->response_status = AWS_HTTP_STATUS_UNKNOWN;
-    stream->base.client_data->request = options->request;
 
     return stream;
 

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -120,7 +120,6 @@ error:
 }
 
 static struct aws_http_message *s_message_new_common(struct aws_allocator *allocator) {
-    AWS_PRECONDITION(allocator);
     struct aws_http_message *message = aws_mem_calloc(allocator, 1, sizeof(struct aws_http_message));
     if (!message) {
         goto error;
@@ -141,6 +140,8 @@ error:
 }
 
 struct aws_http_message *aws_http_message_new_request(struct aws_allocator *allocator) {
+    AWS_PRECONDITION(allocator);
+
     struct aws_http_message *message = s_message_new_common(allocator);
     if (message) {
         message->request_data = &message->subclass_data.request;
@@ -149,6 +150,8 @@ struct aws_http_message *aws_http_message_new_request(struct aws_allocator *allo
 }
 
 struct aws_http_message *aws_http_message_new_response(struct aws_allocator *allocator) {
+    AWS_PRECONDITION(allocator);
+
     struct aws_http_message *message = s_message_new_common(allocator);
     if (message) {
         message->response_data = &message->subclass_data.response;
@@ -462,18 +465,10 @@ int aws_http_stream_configure_server_request_handler(
     return stream->vtable->configure_server_request_handler(stream, options);
 }
 
-int aws_http_stream_send_response(struct aws_http_stream *stream, const struct aws_http_response_options *options) {
-
+int aws_http_stream_send_response(struct aws_http_stream *stream, struct aws_http_message *response) {
     AWS_PRECONDITION(stream);
-    if (!options || options->self_size == 0) {
-        AWS_LOGF_ERROR(
-            AWS_LS_HTTP_CONNECTION,
-            "id=%p: Cannot send response, options are invalid.",
-            (void *)(stream ? stream->owning_connection : NULL));
-        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
-    }
-
-    return stream->owning_connection->vtable->stream_send_response(stream, options);
+    AWS_PRECONDITION(response);
+    return stream->owning_connection->vtable->stream_send_response(stream, response);
 }
 
 void aws_http_stream_release(struct aws_http_stream *stream) {

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -416,7 +416,10 @@ int aws_http_message_get_header(
 }
 
 struct aws_http_stream *aws_http_stream_new_client_request(const struct aws_http_request_options *options) {
-    if (!options || options->self_size == 0 || !options->client_connection || !options->request) {
+    AWS_PRECONDITION(options);
+    if (options->self_size == 0 || !options->client_connection || !options->request ||
+        !aws_http_message_is_request(options->request)) {
+
         AWS_LOGF_ERROR(
             AWS_LS_HTTP_CONNECTION,
             "id=%p: Cannot create client request, options are invalid.",
@@ -468,6 +471,7 @@ int aws_http_stream_configure_server_request_handler(
 int aws_http_stream_send_response(struct aws_http_stream *stream, struct aws_http_message *response) {
     AWS_PRECONDITION(stream);
     AWS_PRECONDITION(response);
+    AWS_PRECONDITION(aws_http_message_is_response(response));
     return stream->owning_connection->vtable->stream_send_response(stream, response);
 }
 


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
