### PR TITLE
Remove amount_read param from elasticurl stream

### DIFF
--- a/bin/elasticurl/main.c
+++ b/bin/elasticurl/main.c
@@ -354,8 +354,7 @@ enum aws_http_outgoing_body_state s_stream_outgoing_body_fn(
         return AWS_HTTP_OUTGOING_BODY_DONE;
     }
 
-    size_t amount_read = 0;
-    if (aws_input_stream_read(app_ctx->input_body, buf, &amount_read)) {
+    if (aws_input_stream_read(app_ctx->input_body, buf)) {
         return AWS_HTTP_OUTGOING_BODY_DONE;
     }
 

--- a/source/connection.c
+++ b/source/connection.c
@@ -394,6 +394,7 @@ struct aws_http_server *aws_http_server_new(const struct aws_http_server_options
             options->tls_options,
             s_server_bootstrap_on_accept_channel_setup,
             s_server_bootstrap_on_accept_channel_shutdown,
+            NULL,
             server);
     } else {
         server->socket = aws_server_bootstrap_new_socket_listener(
@@ -402,6 +403,7 @@ struct aws_http_server *aws_http_server_new(const struct aws_http_server_options
             options->socket_options,
             s_server_bootstrap_on_accept_channel_setup,
             s_server_bootstrap_on_accept_channel_shutdown,
+            NULL,
             server);
     }
 


### PR DESCRIPTION
This is just temp until H1B merges but still.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
