### PR TITLE
H1B: stream::new_client_request() -> connection.make_request()

### DIFF
--- a/bin/elasticurl/main.c
+++ b/bin/elasticurl/main.c
@@ -476,20 +476,19 @@ static void s_on_signing_complete(struct aws_http_message *request, int error_co
         aws_http_message_get_header(app_ctx->request, &headers[i], i);
     }
 
-    struct aws_http_request_options final_request;
-    AWS_ZERO_STRUCT(final_request);
-    final_request.self_size = sizeof(struct aws_http_request_options);
-    final_request.user_data = app_ctx;
-    final_request.client_connection = app_ctx->connection;
-    final_request.request = app_ctx->request;
-    final_request.on_response_headers = s_on_incoming_headers_fn;
-    final_request.on_response_header_block_done = s_on_incoming_header_block_done_fn;
-    final_request.on_response_body = s_on_incoming_body_fn;
-    final_request.on_complete = s_on_stream_complete_fn;
+    struct aws_http_make_request_options final_request = {
+        .self_size = sizeof(final_request),
+        .user_data = app_ctx,
+        .request = app_ctx->request,
+        .on_response_headers = s_on_incoming_headers_fn,
+        .on_response_header_block_done = s_on_incoming_header_block_done_fn,
+        .on_response_body = s_on_incoming_body_fn,
+        .on_complete = s_on_stream_complete_fn,
+    };
 
     app_ctx->response_code_written = false;
 
-    struct aws_http_stream *stream = aws_http_stream_new_client_request(&final_request);
+    struct aws_http_stream *stream = aws_http_connection_make_request(app_ctx->connection, &final_request);
     if (!stream) {
         fprintf(stderr, "failed to create request.");
         exit(1);

--- a/include/aws/http/private/connection_impl.h
+++ b/include/aws/http/private/connection_impl.h
@@ -26,7 +26,7 @@
 #include <aws/io/channel_bootstrap.h>
 
 struct aws_http_message;
-struct aws_http_request_options;
+struct aws_http_make_request_options;
 struct aws_http_request_handler_options;
 struct aws_http_stream;
 
@@ -57,7 +57,10 @@ struct aws_http_connection_system_vtable {
 struct aws_http_connection_vtable {
     struct aws_channel_handler_vtable channel_handler_vtable;
 
-    struct aws_http_stream *(*new_client_request_stream)(const struct aws_http_request_options *options);
+    struct aws_http_stream *(*make_request)(
+        struct aws_http_connection *client_connection,
+        const struct aws_http_make_request_options *options);
+
     struct aws_http_stream *(*new_server_request_handler_stream)(
         const struct aws_http_request_handler_options *options);
     int (*stream_send_response)(struct aws_http_stream *stream, struct aws_http_message *response);

--- a/include/aws/http/private/h1_stream.h
+++ b/include/aws/http/private/h1_stream.h
@@ -45,7 +45,9 @@ struct aws_h1_stream {
 AWS_EXTERN_C_BEGIN
 
 AWS_HTTP_API
-struct aws_h1_stream *aws_h1_stream_new_request(const struct aws_http_request_options *options);
+struct aws_h1_stream *aws_h1_stream_new_request(
+    struct aws_http_connection *client_connection,
+    const struct aws_http_make_request_options *options);
 
 AWS_HTTP_API
 struct aws_h1_stream *aws_h1_stream_new_request_handler(const struct aws_http_request_handler_options *options);

--- a/include/aws/http/private/websocket_impl.h
+++ b/include/aws/http/private/websocket_impl.h
@@ -20,7 +20,7 @@
 
 struct aws_http_client_connection_options;
 struct aws_http_connection;
-struct aws_http_request_options;
+struct aws_http_make_request_options;
 
 /* RFC-6455 Section 5.2 Base Framing Protocol
  * Payload length:  7 bits, 7+16 bits, or 7+64 bits
@@ -82,7 +82,9 @@ struct aws_websocket_client_bootstrap_system_vtable {
     void (*aws_http_connection_release)(struct aws_http_connection *connection);
     void (*aws_http_connection_close)(struct aws_http_connection *connection);
     struct aws_channel *(*aws_http_connection_get_channel)(struct aws_http_connection *connection);
-    struct aws_http_stream *(*aws_http_stream_new_client_request)(const struct aws_http_request_options *options);
+    struct aws_http_stream *(*aws_http_connection_make_request)(
+        struct aws_http_connection *client_connection,
+        const struct aws_http_make_request_options *options);
     void (*aws_http_stream_release)(struct aws_http_stream *stream);
     struct aws_http_connection *(*aws_http_stream_get_connection)(const struct aws_http_stream *stream);
     int (*aws_http_stream_get_incoming_response_status)(const struct aws_http_stream *stream, int *out_status);

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -120,21 +120,16 @@ typedef void(aws_http_on_stream_complete_fn)(struct aws_http_stream *stream, int
 
 /**
  * Options for creating a stream which sends a request from the client and receives a response from the server.
- * Initialize with AWS_HTTP_REQUEST_OPTIONS_INIT to set default values.
  */
-struct aws_http_request_options {
+struct aws_http_make_request_options {
     /**
      * The sizeof() this struct, used for versioning.
-     * Set by AWS_HTTP_REQUEST_OPTIONS_INIT.
+     * Required.
      */
     size_t self_size;
 
     /**
-     * Required.
-     */
-    struct aws_http_connection *client_connection;
-
-    /**
+     * Definition for outgoing request.
      * Required.
      * This object must stay alive at least until on_complete is called.
      */
@@ -181,12 +176,6 @@ struct aws_http_request_options {
      */
     bool manual_window_management;
 };
-
-/**
- * Initializes aws_http_request_options with default values.
- */
-#define AWS_HTTP_REQUEST_OPTIONS_INIT                                                                                  \
-    { .self_size = sizeof(struct aws_http_request_options), }
 
 struct aws_http_request_handler_options {
     /* Set to sizeof() this struct, used for versioning. */
@@ -399,10 +388,15 @@ int aws_http_message_erase_header(struct aws_http_message *message, size_t index
 /**
  * Create a stream, with a client connection sending a request.
  * The request starts sending automatically once the stream is created.
- * The `def`, and all memory it references, is copied during this call.
+ * The `options` are copied during this call.
+ *
+ * Tip for language bindings: Do not bind the `options` struct. Use something more natural for your language,
+ * such as Builder Pattern in Java, or Python's ability to take many optional arguments by name.
  */
 AWS_HTTP_API
-struct aws_http_stream *aws_http_stream_new_client_request(const struct aws_http_request_options *options);
+struct aws_http_stream *aws_http_connection_make_request(
+    struct aws_http_connection *client_connection,
+    const struct aws_http_make_request_options *options);
 
 /**
  * Create a stream, with a server connection receiving and responding to a request.
@@ -449,7 +443,7 @@ int aws_http_stream_send_response(struct aws_http_stream *stream, struct aws_htt
 /**
  * Manually issue a window update.
  * Note that the stream's default behavior is to issue updates which keep the window at its original size.
- * See aws_http_request_options.manual_window_management for details on letting the window shrink.
+ * See aws_http_make_request_options.manual_window_management for details on letting the window shrink.
  */
 AWS_HTTP_API
 void aws_http_stream_update_window(struct aws_http_stream *stream, size_t increment_size);

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -490,17 +490,15 @@ static int s_make_proxy_connect_request(
         return AWS_OP_ERR;
     }
 
-    struct aws_http_request_options request_options;
-    AWS_ZERO_STRUCT(request_options);
+    struct aws_http_make_request_options request_options = {
+        .self_size = sizeof(request_options),
+        .request = request,
+        .user_data = user_data,
+        .on_response_header_block_done = s_aws_http_on_incoming_header_block_done_tls_proxy,
+        .on_complete = s_aws_http_on_stream_complete_tls_proxy,
+    };
 
-    request_options.self_size = sizeof(struct aws_http_request_options);
-    request_options.client_connection = connection;
-    request_options.request = request;
-    request_options.user_data = user_data;
-    request_options.on_response_header_block_done = s_aws_http_on_incoming_header_block_done_tls_proxy;
-    request_options.on_complete = s_aws_http_on_stream_complete_tls_proxy;
-
-    struct aws_http_stream *stream = aws_http_stream_new_client_request(&request_options);
+    struct aws_http_stream *stream = aws_http_connection_make_request(connection, &request_options);
     if (stream == NULL) {
         goto on_error;
     }

--- a/tests/integration_test_proxy.c
+++ b/tests/integration_test_proxy.c
@@ -133,18 +133,17 @@ static int s_do_proxy_request_test(
     };
     aws_http_message_add_header(request, accept_header);
 
-    struct aws_http_request_options request_options;
-    AWS_ZERO_STRUCT(request_options);
-    request_options.client_connection = tester.client_connection;
-    request_options.request = request;
-    request_options.self_size = sizeof(struct aws_http_request_options);
-    request_options.user_data = &tester;
-    request_options.on_response_headers = s_aws_http_on_incoming_headers_proxy_test;
-    request_options.on_response_header_block_done = s_aws_http_on_incoming_header_block_done_proxy_test;
-    request_options.on_response_body = s_aws_http_on_incoming_body_proxy_test;
-    request_options.on_complete = s_aws_http_on_stream_complete_proxy_test;
+    struct aws_http_make_request_options request_options = {
+        .self_size = sizeof(request_options),
+        .request = request,
+        .user_data = &tester,
+        .on_response_headers = s_aws_http_on_incoming_headers_proxy_test,
+        .on_response_header_block_done = s_aws_http_on_incoming_header_block_done_proxy_test,
+        .on_response_body = s_aws_http_on_incoming_body_proxy_test,
+        .on_complete = s_aws_http_on_stream_complete_proxy_test,
+    };
 
-    struct aws_http_stream *stream = aws_http_stream_new_client_request(&request_options);
+    struct aws_http_stream *stream = aws_http_connection_make_request(tester.client_connection, &request_options);
     (void)stream;
 
     ASSERT_SUCCESS(proxy_tester_wait(&tester, proxy_tester_request_complete_pred_fn));

--- a/tests/test_proxy.c
+++ b/tests/test_proxy.c
@@ -409,14 +409,13 @@ static int s_do_http_proxy_request_transform_test(struct aws_allocator *allocato
     struct aws_http_message *untransformed_request = s_build_http_request(allocator);
     struct aws_http_message *request = s_build_http_request(allocator);
 
-    struct aws_http_request_options request_options;
-    AWS_ZERO_STRUCT(request_options);
-    request_options.client_connection = tester.client_connection;
-    request_options.request = request;
-    request_options.self_size = sizeof(struct aws_http_request_options);
-    request_options.user_data = &tester;
+    struct aws_http_make_request_options request_options = {
+        .self_size = sizeof(request_options),
+        .request = request,
+        .user_data = &tester,
+    };
 
-    struct aws_http_stream *stream = aws_http_stream_new_client_request(&request_options);
+    struct aws_http_stream *stream = aws_http_connection_make_request(tester.client_connection, &request_options);
     testing_channel_run_currently_queued_tasks(tester.testing_channel);
 
     s_verify_transformed_request(untransformed_request, request, use_basic_auth, allocator);

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -178,14 +178,15 @@ static int s_test_tls_download_medium_file(struct aws_allocator *allocator, void
     };
     ASSERT_SUCCESS(aws_http_message_add_header(request, header_host));
 
-    struct aws_http_request_options req_options = AWS_HTTP_REQUEST_OPTIONS_INIT;
-    req_options.client_connection = test.client_connection;
-    req_options.request = request;
-    req_options.on_response_body = s_on_stream_body;
-    req_options.on_complete = s_on_stream_complete;
-    req_options.user_data = &test;
+    struct aws_http_make_request_options req_options = {
+        .self_size = sizeof(req_options),
+        .request = request,
+        .on_response_body = s_on_stream_body,
+        .on_complete = s_on_stream_complete,
+        .user_data = &test,
+    };
 
-    ASSERT_NOT_NULL(test.stream = aws_http_stream_new_client_request(&req_options));
+    ASSERT_NOT_NULL(test.stream = aws_http_connection_make_request(test.client_connection, &req_options));
 
     /* wait for the request to complete */
     s_test_wait(&test, s_stream_wait_pred);

--- a/tests/test_websocket_bootstrap.c
+++ b/tests/test_websocket_bootstrap.c
@@ -35,7 +35,7 @@ static void s_mock_http_connection_release(struct aws_http_connection *connectio
 static void s_mock_http_connection_close(struct aws_http_connection *connection);
 static struct aws_channel *s_mock_http_connection_get_channel(struct aws_http_connection *connection);
 static struct aws_http_stream *s_mock_http_connection_make_request(
-    struct aws_http_connection *connection,
+    struct aws_http_connection *client_connection,
     const struct aws_http_make_request_options *options);
 static void s_mock_http_stream_release(struct aws_http_stream *stream);
 static struct aws_http_connection *s_mock_http_stream_get_connection(const struct aws_http_stream *stream);

--- a/tests/test_websocket_bootstrap.c
+++ b/tests/test_websocket_bootstrap.c
@@ -34,7 +34,9 @@ static int s_mock_http_client_connect(const struct aws_http_client_connection_op
 static void s_mock_http_connection_release(struct aws_http_connection *connection);
 static void s_mock_http_connection_close(struct aws_http_connection *connection);
 static struct aws_channel *s_mock_http_connection_get_channel(struct aws_http_connection *connection);
-static struct aws_http_stream *s_mock_http_stream_new_client_request(const struct aws_http_request_options *options);
+static struct aws_http_stream *s_mock_http_connection_make_request(
+    struct aws_http_connection *connection,
+    const struct aws_http_make_request_options *options);
 static void s_mock_http_stream_release(struct aws_http_stream *stream);
 static struct aws_http_connection *s_mock_http_stream_get_connection(const struct aws_http_stream *stream);
 static int s_mock_http_stream_get_incoming_response_status(const struct aws_http_stream *stream, int *out_status);
@@ -45,7 +47,7 @@ static const struct aws_websocket_client_bootstrap_system_vtable s_mock_system_v
     .aws_http_connection_release = s_mock_http_connection_release,
     .aws_http_connection_close = s_mock_http_connection_close,
     .aws_http_connection_get_channel = s_mock_http_connection_get_channel,
-    .aws_http_stream_new_client_request = s_mock_http_stream_new_client_request,
+    .aws_http_connection_make_request = s_mock_http_connection_make_request,
     .aws_http_stream_release = s_mock_http_stream_release,
     .aws_http_stream_get_connection = s_mock_http_stream_get_connection,
     .aws_http_stream_get_incoming_response_status = s_mock_http_stream_get_incoming_response_status,
@@ -268,7 +270,11 @@ static struct aws_channel *s_mock_http_connection_get_channel(struct aws_http_co
     return s_mock_channel;
 }
 
-static struct aws_http_stream *s_mock_http_stream_new_client_request(const struct aws_http_request_options *options) {
+static struct aws_http_stream *s_mock_http_connection_make_request(
+    struct aws_http_connection *client_connection,
+    const struct aws_http_make_request_options *options) {
+
+    AWS_FATAL_ASSERT(client_connection);
     AWS_FATAL_ASSERT(options);
     AWS_FATAL_ASSERT(!s_tester.http_connection_release_called);
     AWS_FATAL_ASSERT(!s_tester.http_stream_new_called_successfully); /* ensure we're only called once */


### PR DESCRIPTION
One last bit of API breakage before merging H1B. This makes the C impl match more closely with what we ended up with in the bindings.

Look at `request_response.h` to see what actually changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
