### PR TITLE
aws_http_header_type -> aws_http_header_block

### DIFF
--- a/bin/elasticurl/main.c
+++ b/bin/elasticurl/main.c
@@ -334,14 +334,19 @@ static int s_on_incoming_body_fn(struct aws_http_stream *stream, const struct aw
 
 static int s_on_incoming_headers_fn(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
+
     struct elasticurl_ctx *app_ctx = user_data;
     (void)app_ctx;
     (void)stream;
-    (void)header_type;
+
+    /* Ignore informational headers */
+    if (header_block == AWS_HTTP_HEADER_BLOCK_INFORMATIONAL) {
+        return AWS_OP_SUCCESS;
+    }
 
     if (app_ctx->include_headers) {
         if (!app_ctx->response_code_written) {
@@ -364,10 +369,10 @@ static int s_on_incoming_headers_fn(
 
 static int s_on_incoming_header_block_done_fn(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     (void)user_data;
 
     return AWS_OP_SUCCESS;

--- a/include/aws/http/private/h1_decoder.h
+++ b/include/aws/http/private/h1_decoder.h
@@ -51,7 +51,7 @@ AWS_HTTP_API int aws_h1_decoder_get_encoding_flags(const struct aws_h1_decoder *
 
 AWS_HTTP_API size_t aws_h1_decoder_get_content_length(const struct aws_h1_decoder *decoder);
 AWS_HTTP_API bool aws_h1_decoder_get_body_headers_ignored(const struct aws_h1_decoder *decoder);
-AWS_HTTP_API enum aws_http_header_type aws_h1_decoder_get_header_type(const struct aws_h1_decoder *decoder);
+AWS_HTTP_API enum aws_http_header_block aws_h1_decoder_get_header_block(const struct aws_h1_decoder *decoder);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -44,7 +44,7 @@ struct aws_http_header {
  * MAIN: Main header block sent with request or response.
  * TRAILING: Headers sent after the body of a request or response.
  */
-enum aws_http_header_type {
+enum aws_http_header_block {
     AWS_HTTP_HEADER_BLOCK_MAIN,
     AWS_HTTP_HEADER_BLOCK_INFORMATIONAL,
     AWS_HTTP_HEADER_BLOCK_TRAILING,
@@ -98,13 +98,13 @@ typedef void(aws_http_message_transform_fn)(
  */
 typedef int(aws_http_on_incoming_headers_fn)(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data);
 
 /**
- * Invoked when the incoming header block of this header_type(informational/normal/trailing) has been completely read.
+ * Invoked when the incoming header block of this type(informational/main/trailing) has been completely read.
  * This is always invoked on the HTTP connection's event-loop thread.
  *
  * Return AWS_OP_SUCCESS to continue processing the stream.
@@ -112,7 +112,7 @@ typedef int(aws_http_on_incoming_headers_fn)(
  */
 typedef int(aws_http_on_incoming_header_block_done_fn)(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data);
 
 /**

--- a/source/h1_decoder.c
+++ b/source/h1_decoder.c
@@ -48,7 +48,7 @@ struct aws_h1_decoder {
     bool is_done;
     bool body_headers_ignored;
     bool body_headers_forbidden;
-    enum aws_http_header_type header_type;
+    enum aws_http_header_block header_block;
     void *logging_id;
 
     /* User callbacks and settings. */
@@ -328,7 +328,7 @@ static void s_reset_state(struct aws_h1_decoder *decoder) {
     decoder->body_headers_ignored = false;
     decoder->body_headers_forbidden = false;
     /* set to normal by default */
-    decoder->header_type = AWS_HTTP_HEADER_BLOCK_MAIN;
+    decoder->header_block = AWS_HTTP_HEADER_BLOCK_MAIN;
 }
 
 static int s_state_unchunked_body(struct aws_h1_decoder *decoder, struct aws_byte_cursor *input) {
@@ -753,7 +753,7 @@ static int s_linestate_response(struct aws_h1_decoder *decoder, struct aws_byte_
     decoder->body_headers_forbidden = code_val == AWS_HTTP_STATUS_204_NO_CONTENT || code_val / 100 == 1;
 
     if (s_check_info_response_status_code(code_val)) {
-        decoder->header_type = AWS_HTTP_HEADER_BLOCK_INFORMATIONAL;
+        decoder->header_block = AWS_HTTP_HEADER_BLOCK_INFORMATIONAL;
     }
 
     err = decoder->vtable.on_response((int)code_val, decoder->user_data);
@@ -825,8 +825,8 @@ bool aws_h1_decoder_get_body_headers_ignored(const struct aws_h1_decoder *decode
     return decoder->body_headers_ignored;
 }
 
-enum aws_http_header_type aws_h1_decoder_get_header_type(const struct aws_h1_decoder *decoder) {
-    return decoder->header_type;
+enum aws_http_header_block aws_h1_decoder_get_header_block(const struct aws_h1_decoder *decoder) {
+    return decoder->header_block;
 }
 
 void aws_h1_decoder_set_logging_id(struct aws_h1_decoder *decoder, void *id) {

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -368,20 +368,21 @@ on_error:
  */
 static int s_aws_http_on_incoming_header_block_done_tls_proxy(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
 
-    (void)header_type;
-
     struct aws_http_proxy_user_data *context = user_data;
-    int status = 0;
-    if (aws_http_stream_get_incoming_response_status(stream, &status) || status != 200) {
-        AWS_LOGF_ERROR(
-            AWS_LS_HTTP_CONNECTION,
-            "(%p) Proxy CONNECT request failed with status code %d",
-            (void *)context->connection,
-            status);
-        context->error_code = AWS_ERROR_HTTP_PROXY_TLS_CONNECT_FAILED;
+
+    if (header_block == AWS_HTTP_HEADER_BLOCK_MAIN) {
+        int status = 0;
+        if (aws_http_stream_get_incoming_response_status(stream, &status) || status != 200) {
+            AWS_LOGF_ERROR(
+                AWS_LS_HTTP_CONNECTION,
+                "(%p) Proxy CONNECT request failed with status code %d",
+                (void *)context->connection,
+                status);
+            context->error_code = AWS_ERROR_HTTP_PROXY_TLS_CONNECT_FAILED;
+        }
     }
 
     return AWS_OP_SUCCESS;

--- a/source/websocket_bootstrap.c
+++ b/source/websocket_bootstrap.c
@@ -95,7 +95,7 @@ static void s_ws_bootstrap_on_http_shutdown(
     void *user_data);
 static int s_ws_bootstrap_on_handshake_response_headers(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data);
@@ -395,11 +395,11 @@ static void s_ws_bootstrap_on_http_shutdown(
 
 static int s_ws_bootstrap_on_handshake_response_headers(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
-    (void)header_type;
+    (void)header_block;
 
     struct aws_websocket_client_bootstrap *ws_bootstrap = user_data;
     int err;

--- a/tests/integration_test_proxy.c
+++ b/tests/integration_test_proxy.c
@@ -28,13 +28,13 @@ static int s_response_status_code = 0;
 
 static int s_aws_http_on_incoming_headers_proxy_test(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
     (void)stream;
     (void)user_data;
-    (void)header_type;
+    (void)header_block;
 
     for (size_t i = 0; i < num_headers; ++i) {
         const struct aws_byte_cursor *name = &header_array[i].name;
@@ -48,9 +48,9 @@ static int s_aws_http_on_incoming_headers_proxy_test(
 
 static int s_aws_http_on_incoming_header_block_done_proxy_test(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
-    (void)header_type;
+    (void)header_block;
 
     struct proxy_tester *context = user_data;
     if (aws_http_stream_get_incoming_response_status(stream, &s_response_status_code) == AWS_OP_SUCCESS) {

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -485,7 +485,7 @@ struct response_tester {
 
 static int s_response_tester_on_headers(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
@@ -496,7 +496,7 @@ static int s_response_tester_on_headers(
 
     struct aws_byte_buf *storage = &response->storage;
     const struct aws_http_header *in_header = header_array;
-    struct aws_http_header *my_header = header_type == AWS_HTTP_HEADER_BLOCK_INFORMATIONAL
+    struct aws_http_header *my_header = header_block == AWS_HTTP_HEADER_BLOCK_INFORMATIONAL
                                             ? response->info_headers + response->num_info_headers
                                             : response->headers + response->num_headers;
     for (size_t i = 0; i < num_headers; ++i) {
@@ -512,9 +512,9 @@ static int s_response_tester_on_headers(
         in_header++;
         my_header++;
     }
-    if (header_type == AWS_HTTP_HEADER_BLOCK_INFORMATIONAL) {
+    if (header_block == AWS_HTTP_HEADER_BLOCK_INFORMATIONAL) {
         response->num_info_headers += num_headers;
-    } else if (header_type == AWS_HTTP_HEADER_BLOCK_MAIN) {
+    } else if (header_block == AWS_HTTP_HEADER_BLOCK_MAIN) {
         response->num_headers += num_headers;
     }
 
@@ -523,10 +523,10 @@ static int s_response_tester_on_headers(
 
 static int s_response_tester_on_header_block_done(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     struct response_tester *response = user_data;
 
     response->on_response_header_block_done_cb_count++;
@@ -1489,13 +1489,13 @@ static struct aws_input_stream_vtable s_error_from_outgoing_body_vtable = {
 
 static int s_error_from_incoming_headers(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
 
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     (void)header_array;
     (void)num_headers;
     return s_error_from_callback_common(user_data, REQUEST_CALLBACK_INCOMING_HEADERS);
@@ -1503,10 +1503,10 @@ static int s_error_from_incoming_headers(
 
 static int s_error_from_incoming_headers_done(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     return s_error_from_callback_common(user_data, REQUEST_CALLBACK_INCOMING_HEADERS_DONE);
 }
 

--- a/tests/test_h1_server.c
+++ b/tests/test_h1_server.c
@@ -77,13 +77,13 @@ struct tester {
 
 static int s_tester_on_request_header(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
 
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     struct tester_request *request = user_data;
     struct aws_byte_buf *storage = &request->storage;
     const struct aws_http_header *in_header = header_array;
@@ -107,12 +107,12 @@ static int s_tester_on_request_header(
 
 static int s_tester_on_request_header_block_done(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     struct tester_request *request = user_data;
-    if (header_type == AWS_HTTP_HEADER_BLOCK_MAIN) {
+    if (header_block == AWS_HTTP_HEADER_BLOCK_MAIN) {
         AWS_FATAL_ASSERT(request->header_done == false);
         request->header_done = true;
     }
@@ -1200,13 +1200,13 @@ static struct aws_input_stream_vtable s_error_from_outgoing_body_vtable = {
 
 static int s_error_from_incoming_headers(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     const struct aws_http_header *header_array,
     size_t num_headers,
     void *user_data) {
 
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     (void)header_array;
     (void)num_headers;
     return s_error_from_callback_common(user_data, REQUEST_HANDLER_CALLBACK_INCOMING_HEADERS);
@@ -1214,10 +1214,10 @@ static int s_error_from_incoming_headers(
 
 static int s_error_from_incoming_headers_done(
     struct aws_http_stream *stream,
-    enum aws_http_header_type header_type,
+    enum aws_http_header_block header_block,
     void *user_data) {
     (void)stream;
-    (void)header_type;
+    (void)header_block;
     return s_error_from_callback_common(user_data, REQUEST_HANDLER_CALLBACK_INCOMING_HEADERS_DONE);
 }
 


### PR DESCRIPTION
enum name matches its values

```
enum aws_http_header_block {
    AWS_HTTP_HEADER_BLOCK_MAIN,
    AWS_HTTP_HEADER_BLOCK_INFORMATIONAL,
    AWS_HTTP_HEADER_BLOCK_TRAILING,
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
