### PR TITLE
Don't fire on_body for empty chunks of data

### DIFF
--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -1079,6 +1079,11 @@ static int s_decoder_on_body(const struct aws_byte_cursor *data, bool finished, 
         return AWS_OP_ERR;
     }
 
+    /* No need to invoke callback for 0-length data */
+    if (data->len == 0) {
+        return AWS_OP_SUCCESS;
+    }
+
     AWS_LOGF_TRACE(
         AWS_LS_HTTP_STREAM, "id=%p: Incoming body: %zu bytes received.", (void *)&incoming_stream->base, data->len);
 


### PR DESCRIPTION
This was leading to aws-crt-python passing `None` to its on_body callback instead of a byte buffer. Seems better to nip this complexity at the source than in each crt and/or user code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
