### PR TITLE
Rewrite HPACK dyn table to have size be in octets instead of elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ cmake-build*
 *.out
 *.app
 
+corpus/

--- a/include/aws/http/private/hpack.h
+++ b/include/aws/http/private/hpack.h
@@ -15,7 +15,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 #include <aws/http/http.h>
 
 struct aws_byte_buf;
@@ -49,6 +48,10 @@ void aws_hpack_context_destroy(struct aws_hpack_context *context);
 AWS_HTTP_API
 void aws_hpack_context_reset_decode(struct aws_hpack_context *context);
 
+/* Returns the hpack size of a header (name.len + value.len + 32) [4.1] */
+AWS_HTTP_API
+size_t aws_hpack_get_header_size(const struct aws_http_header *header);
+
 AWS_HTTP_API
 const struct aws_http_header *aws_hpack_get_header(const struct aws_hpack_context *context, size_t index);
 /* A return value of 0 indicates that the header wasn't found */
@@ -61,8 +64,11 @@ size_t aws_hpack_find_index(
 AWS_HTTP_API
 int aws_hpack_insert_header(struct aws_hpack_context *context, const struct aws_http_header *header);
 
+/**
+ * Set the max size of the dynamic table (in octets). The size of each header is name.len + value.len + 32 [4.1].
+ */
 AWS_HTTP_API
-int aws_hpack_resize_dynamic_table(struct aws_hpack_context *context, size_t new_max_elements);
+int aws_hpack_resize_dynamic_table(struct aws_hpack_context *context, size_t new_max_size);
 
 /* Public for testing purposes */
 AWS_HTTP_API

--- a/include/aws/http/private/hpack.h
+++ b/include/aws/http/private/hpack.h
@@ -40,7 +40,11 @@ void aws_hpack_static_table_clean_up(void);
 
 /* General HPACK API */
 AWS_HTTP_API
-struct aws_hpack_context *aws_hpack_context_new(struct aws_allocator *allocator);
+struct aws_hpack_context *aws_hpack_context_new(
+    struct aws_allocator *allocator,
+    enum aws_http_log_subject log_subject,
+    void *log_id);
+
 AWS_HTTP_API
 void aws_hpack_context_destroy(struct aws_hpack_context *context);
 

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -12,7 +12,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 #include <aws/http/private/h2_decoder.h>
 
 #include <aws/http/private/hpack.h>
@@ -197,7 +196,7 @@ struct aws_h2_decoder *aws_h2_decoder_new(struct aws_h2_decoder_params *params) 
 
     decoder->scratch = aws_byte_buf_from_array(scratch_buf, s_scratch_space_size);
 
-    decoder->hpack = aws_hpack_context_new(params->alloc);
+    decoder->hpack = aws_hpack_context_new(params->alloc, AWS_LS_HTTP_DECODER, decoder);
     if (!decoder->hpack) {
         goto failed_new_hpack;
     }

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -447,7 +447,7 @@ int aws_h2_frame_encoder_init(struct aws_h2_frame_encoder *encoder, struct aws_a
     AWS_ZERO_STRUCT(*encoder);
     encoder->allocator = allocator;
 
-    encoder->hpack = aws_hpack_context_new(allocator);
+    encoder->hpack = aws_hpack_context_new(allocator, AWS_LS_HTTP_ENCODER, encoder);
     if (!encoder->hpack) {
         return AWS_OP_ERR;
     }
@@ -470,7 +470,7 @@ int aws_h2_frame_decoder_init(struct aws_h2_frame_decoder *decoder, struct aws_a
     AWS_ZERO_STRUCT(*decoder);
     decoder->allocator = allocator;
 
-    decoder->hpack = aws_hpack_context_new(allocator);
+    decoder->hpack = aws_hpack_context_new(allocator, AWS_LS_HTTP_DECODER, decoder);
     if (!decoder->hpack) {
         goto failed_create_hpack;
     }

--- a/source/hpack.c
+++ b/source/hpack.c
@@ -427,10 +427,7 @@ static int s_dynamic_table_shrink(struct aws_hpack_context *context, size_t max_
 
         /* Remove old header from hash tables */
         if (aws_hash_table_remove(&context->dynamic_table.reverse_lookup, back, NULL, NULL)) {
-            HPACK_LOG(
-                ERROR,
-                context,
-                "Failed to remove header from the reverse lookup table");
+            HPACK_LOG(ERROR, context, "Failed to remove header from the reverse lookup table");
             goto error;
         }
 
@@ -440,10 +437,7 @@ static int s_dynamic_table_shrink(struct aws_hpack_context *context, size_t max_
         aws_hash_table_find(&context->dynamic_table.reverse_lookup_name_only, &back->name, &elem);
         if (elem && elem->key == back) {
             if (aws_hash_table_remove_element(&context->dynamic_table.reverse_lookup_name_only, elem)) {
-                HPACK_LOG(
-                    ERROR,
-                    context,
-                    "Failed to remove header from the reverse lookup (name-only) table");
+                HPACK_LOG(ERROR, context, "Failed to remove header from the reverse lookup (name-only) table");
                 goto error;
             }
         }
@@ -559,7 +553,8 @@ int aws_hpack_insert_header(struct aws_hpack_context *context, const struct aws_
         goto error;
     }
 
-    /* Rotate out headers until there's room for the new header (this function will return immediately if nothing needs to be evicted) */
+    /* Rotate out headers until there's room for the new header (this function will return immediately if nothing needs
+     * to be evicted) */
     if (s_dynamic_table_shrink(context, context->dynamic_table.max_size - header_size)) {
         goto error;
     }

--- a/tests/test_hpack.c
+++ b/tests/test_hpack.c
@@ -12,7 +12,6 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 #include <aws/testing/aws_test_harness.h>
 
 #include <aws/http/private/hpack.h>
@@ -118,7 +117,7 @@ static int test_hpack_decode_integer(struct aws_allocator *allocator, void *ctx)
     /* Test encoding integers
        Test cases taken from https://httpwg.org/specs/rfc7541.html#integer.representation.examples */
 
-    struct aws_hpack_context *hpack = aws_hpack_context_new(allocator);
+    struct aws_hpack_context *hpack = aws_hpack_context_new(allocator, AWS_LS_HTTP_GENERAL, NULL);
     ASSERT_NOT_NULL(hpack);
     ASSERT_SUCCESS(aws_hpack_resize_dynamic_table(hpack, 0));
 
@@ -245,7 +244,7 @@ static int test_hpack_static_table_find(struct aws_allocator *allocator, void *c
     (void)ctx;
 
     aws_hpack_static_table_init(allocator);
-    struct aws_hpack_context *context = aws_hpack_context_new(allocator);
+    struct aws_hpack_context *context = aws_hpack_context_new(allocator, AWS_LS_HTTP_GENERAL, NULL);
     ASSERT_NOT_NULL(context);
     ASSERT_SUCCESS(aws_hpack_resize_dynamic_table(context, 0));
 
@@ -279,7 +278,7 @@ static int test_hpack_static_table_get(struct aws_allocator *allocator, void *ct
     (void)ctx;
 
     aws_hpack_static_table_init(allocator);
-    struct aws_hpack_context *context = aws_hpack_context_new(allocator);
+    struct aws_hpack_context *context = aws_hpack_context_new(allocator, AWS_LS_HTTP_GENERAL, NULL);
     ASSERT_NOT_NULL(context);
     ASSERT_SUCCESS(aws_hpack_resize_dynamic_table(context, 0));
 
@@ -312,7 +311,7 @@ static int test_hpack_dynamic_table_find(struct aws_allocator *allocator, void *
     (void)ctx;
 
     aws_hpack_static_table_init(allocator);
-    struct aws_hpack_context *context = aws_hpack_context_new(allocator);
+    struct aws_hpack_context *context = aws_hpack_context_new(allocator, AWS_LS_HTTP_GENERAL, NULL);
     ASSERT_NOT_NULL(context);
 
     bool found_value = false;
@@ -362,7 +361,7 @@ static int test_hpack_dynamic_table_get(struct aws_allocator *allocator, void *c
     (void)ctx;
 
     aws_hpack_static_table_init(allocator);
-    struct aws_hpack_context *context = aws_hpack_context_new(allocator);
+    struct aws_hpack_context *context = aws_hpack_context_new(allocator, AWS_LS_HTTP_GENERAL, NULL);
     ASSERT_NOT_NULL(context);
 
     const struct aws_http_header *found = NULL;


### PR DESCRIPTION
I misread the spec the first time, whoops.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
