### PR TITLE
h2 channel handler boilerplate

### DIFF
--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -20,6 +20,9 @@
 #include <aws/common/mutex.h>
 
 #include <aws/http/private/connection_impl.h>
+#include <aws/http/private/h2_frames.h>
+
+struct aws_h2_decoder;
 
 struct aws_h2_connection {
     struct aws_http_connection base;
@@ -27,6 +30,7 @@ struct aws_h2_connection {
     /* Only the event-loop thread may touch this data */
     struct {
         struct aws_h2_decoder *decoder;
+        struct aws_h2_frame_encoder encoder;
     } thread_data;
 
     /* Any thread may touch this data, but the lock must be held */

--- a/include/aws/http/private/h2_decoder.h
+++ b/include/aws/http/private/h2_decoder.h
@@ -48,6 +48,7 @@ struct aws_h2_decoder_params {
     struct aws_allocator *alloc;
     struct aws_h2_decoder_vtable vtable;
     void *userdata;
+    void *logging_id;
 };
 
 struct aws_h2_decoder;
@@ -57,8 +58,6 @@ AWS_EXTERN_C_BEGIN
 AWS_HTTP_API struct aws_h2_decoder *aws_h2_decoder_new(struct aws_h2_decoder_params *params);
 AWS_HTTP_API void aws_h2_decoder_destroy(struct aws_h2_decoder *decoder);
 AWS_HTTP_API int aws_h2_decode(struct aws_h2_decoder *decoder, struct aws_byte_cursor *data);
-
-AWS_HTTP_API void aws_h2_decoder_set_logging_id(struct aws_h2_decoder *decoder, void *id);
 
 AWS_EXTERN_C_END
 

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -1189,6 +1189,7 @@ static struct h1_connection *s_connection_new(struct aws_allocator *alloc, size_
     connection->base.vtable = &s_h1_connection_vtable;
     connection->base.alloc = alloc;
     connection->base.channel_handler.vtable = &s_h1_connection_vtable.channel_handler_vtable;
+    connection->base.channel_handler.alloc = alloc;
     connection->base.channel_handler.impl = connection;
     connection->base.http_version = AWS_HTTP_VERSION_1_1;
     connection->base.initial_window_size = initial_window_size;
@@ -1208,7 +1209,10 @@ static struct h1_connection *s_connection_new(struct aws_allocator *alloc, size_
     int err = aws_mutex_init(&connection->synced_data.lock);
     if (err) {
         AWS_LOGF_ERROR(
-            AWS_LS_HTTP_CONNECTION, "static: Failed to initialize mutex, error %d (%s).", err, aws_error_name(err));
+            AWS_LS_HTTP_CONNECTION,
+            "static: Failed to initialize mutex, error %d (%s).",
+            aws_last_error(),
+            aws_error_name(aws_last_error()));
 
         goto error_mutex;
     }

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -25,7 +25,8 @@
  * Constants
  **********************************************************************************************************************/
 
-static const size_t s_scratch_space_size = 512;
+/* Big enough to hold the "required_bytes" for any state */
+static const size_t s_scratch_space_size = 9;
 
 /* Stream ids & dependencies should only write the bottom 31 bits */
 static const uint32_t s_31_bit_mask = UINT32_MAX >> 1;
@@ -194,6 +195,7 @@ struct aws_h2_decoder *aws_h2_decoder_new(struct aws_h2_decoder_params *params) 
     decoder->alloc = params->alloc;
     decoder->vtable = params->vtable;
     decoder->userdata = params->userdata;
+    decoder->logging_id = params->logging_id;
 
     decoder->scratch = aws_byte_buf_from_array(scratch_buf, s_scratch_space_size);
 
@@ -215,6 +217,9 @@ failed_alloc:
 }
 
 void aws_h2_decoder_destroy(struct aws_h2_decoder *decoder) {
+    if (!decoder) {
+        return;
+    }
     aws_hpack_context_destroy(decoder->hpack);
     aws_mem_release(decoder->alloc, decoder);
 }
@@ -229,6 +234,7 @@ int aws_h2_decode(struct aws_h2_decoder *decoder, struct aws_byte_cursor *data) 
 
     while (data->len) {
         const uint32_t bytes_required = decoder->state.bytes_required;
+        AWS_ASSERT(bytes_required <= decoder->scratch.capacity);
         if (!decoder->scratch.len && data->len >= bytes_required) {
             /* Easy case, there is no scratch and we have enough data, so just send it to the state */
 
@@ -302,10 +308,6 @@ int aws_h2_decode(struct aws_h2_decoder *decoder, struct aws_byte_cursor *data) 
 handle_error:
     decoder->has_errored = true;
     return err;
-}
-
-void aws_h2_decoder_set_logging_id(struct aws_h2_decoder *decoder, void *id) {
-    decoder->logging_id = id;
 }
 
 /* Wrap hpack functions to do payload length checks */

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -25,8 +25,7 @@
  * Constants
  **********************************************************************************************************************/
 
-/* Big enough to hold the "required_bytes" for any state */
-static const size_t s_scratch_space_size = 9;
+static const size_t s_scratch_space_size = 512;
 
 /* Stream ids & dependencies should only write the bottom 31 bits */
 static const uint32_t s_31_bit_mask = UINT32_MAX >> 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -197,6 +197,8 @@ add_test_case(h2_frame_goaway)
 add_test_case(h2_frame_window_update)
 add_test_case(h2_frame_continuation)
 
+add_test_case(h2_client_sanity_check)
+
 add_test_case(server_new_destroy)
 add_test_case(connection_setup_shutdown)
 add_test_case(connection_destroy_server_with_connection_existing)

--- a/tests/test_h2_client.c
+++ b/tests/test_h2_client.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/http/private/h2_connection.h>
+#include <aws/testing/io_testing_channel.h>
+
+#define TEST_CASE(NAME)                                                                                                \
+    AWS_TEST_CASE(NAME, s_test_##NAME);                                                                                \
+    static int s_test_##NAME(struct aws_allocator *allocator, void *ctx)
+
+/* Singleton used by tests in this file */
+struct tester {
+    struct aws_allocator *alloc;
+    struct aws_logger logger;
+    struct aws_http_connection *connection;
+    struct testing_channel testing_channel;
+} s_tester;
+
+static int s_tester_init(struct aws_allocator *alloc, void *ctx) {
+    (void)ctx;
+    aws_http_library_init(alloc);
+
+    s_tester.alloc = alloc;
+
+    struct aws_logger_standard_options logger_options = {
+        .level = AWS_LOG_LEVEL_TRACE,
+        .file = stderr,
+    };
+    ASSERT_SUCCESS(aws_logger_init_standard(&s_tester.logger, alloc, &logger_options));
+    aws_logger_set(&s_tester.logger);
+
+    ASSERT_SUCCESS(testing_channel_init(&s_tester.testing_channel, alloc));
+
+    s_tester.connection = aws_http_connection_new_http2_client(alloc, SIZE_MAX);
+    ASSERT_NOT_NULL(s_tester.connection);
+
+    { /* re-enact marriage vows of http-connection and channel (handled by http-bootstrap in real world) */
+        struct aws_channel_slot *slot = aws_channel_slot_new(s_tester.testing_channel.channel);
+        ASSERT_NOT_NULL(slot);
+        ASSERT_SUCCESS(aws_channel_slot_insert_end(s_tester.testing_channel.channel, slot));
+        ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &s_tester.connection->channel_handler));
+        s_tester.connection->channel_slot = slot;
+        aws_channel_acquire_hold(s_tester.testing_channel.channel);
+    }
+
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+    return AWS_OP_SUCCESS;
+}
+
+static int s_tester_clean_up(void) {
+    aws_http_connection_release(s_tester.connection);
+    ASSERT_SUCCESS(testing_channel_clean_up(&s_tester.testing_channel));
+    aws_http_library_clean_up();
+    aws_logger_clean_up(&s_tester.logger);
+    return AWS_OP_SUCCESS;
+}
+
+/* Test the common setup/teardown used by all tests in this file */
+TEST_CASE(h2_client_sanity_check) {
+    ASSERT_SUCCESS(s_tester_init(allocator, ctx));
+    return s_tester_clean_up();
+}

--- a/tests/test_h2_frames.c
+++ b/tests/test_h2_frames.c
@@ -17,10 +17,6 @@
 
 #include <aws/http/private/h2_frames.h>
 
-#ifdef _MSC_VER
-#    pragma warning(disable : 4232) /* function pointer to dll symbol */
-#endif
-
 enum { S_BUFFER_SIZE = 128 };
 
 struct frame_test_fixture;

--- a/tests/test_h2_headers.c
+++ b/tests/test_h2_headers.c
@@ -18,10 +18,6 @@
 #include <aws/http/private/h2_frames.h>
 #include <aws/http/private/hpack.h>
 
-#ifdef _MSC_VER
-#    pragma warning(disable : 4232) /* function pointer to dll symbol */
-#endif
-
 enum { S_BUFFER_SIZE = 128 };
 
 struct header_test_fixture;


### PR DESCRIPTION
- flesh out channel handler vtable
- create & destroy encoder & decoder
- test_h2_client.c with 1 test and boilerplate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
