### PR TITLE
Use term 'prefix' instead of 'header' for common part of h2 frames

### DIFF
--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -107,16 +107,15 @@ struct aws_h2_frame_header_block {
     struct aws_array_list header_fields;
 };
 
-/* The header present in every h2 frame */
-struct aws_h2_frame_header {
+/* Present in every h2 frame */
+struct aws_h2_frame_base {
     uint8_t type; /* aws_h2_frame_type */
     uint32_t stream_id;
 };
 
 /* Represents a DATA frame */
 struct aws_h2_frame_data {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Flags */
     bool end_stream; /* AWS_H2_FRAME_F_END_STREAM */
@@ -128,8 +127,7 @@ struct aws_h2_frame_data {
 
 /* Represents a HEADERS frame */
 struct aws_h2_frame_headers {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Flags */
     bool end_stream;   /* AWS_H2_FRAME_F_END_STREAM */
@@ -144,8 +142,7 @@ struct aws_h2_frame_headers {
 
 /* Represents a PRIORITY frame */
 struct aws_h2_frame_priority {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Payload */
     struct aws_h2_frame_priority_settings priority;
@@ -153,8 +150,7 @@ struct aws_h2_frame_priority {
 
 /* Represents a RST_STREAM frame */
 struct aws_h2_frame_rst_stream {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Payload */
     enum aws_h2_error_codes error_code;
@@ -168,8 +164,7 @@ struct aws_h2_frame_setting {
 
 /* Represents a SETTINGS frame */
 struct aws_h2_frame_settings {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Flags */
     bool ack; /* AWS_H2_FRAME_F_ACK */
@@ -181,8 +176,7 @@ struct aws_h2_frame_settings {
 
 /* Represents a PUSH_PROMISE frame */
 struct aws_h2_frame_push_promise {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Flags */
     bool end_headers; /* AWS_H2_FRAME_F_END_HEADERS */
@@ -197,8 +191,7 @@ struct aws_h2_frame_push_promise {
 
 /* Represents a PING frame */
 struct aws_h2_frame_ping {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Flags */
     bool ack; /* AWS_H2_FRAME_F_ACK */
@@ -209,8 +202,7 @@ struct aws_h2_frame_ping {
 
 /* Represents a GOAWAY frame */
 struct aws_h2_frame_goaway {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Payload */
     uint32_t last_stream_id;
@@ -220,8 +212,7 @@ struct aws_h2_frame_goaway {
 
 /* Represents a WINDOW_UPDATE frame */
 struct aws_h2_frame_window_update {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Payload */
     uint32_t window_size_increment;
@@ -229,8 +220,7 @@ struct aws_h2_frame_window_update {
 
 /* Represents a CONTINUATION frame */
 struct aws_h2_frame_continuation {
-    /* Header */
-    struct aws_h2_frame_header header;
+    struct aws_h2_frame_base base;
 
     /* Flags */
     bool end_headers; /* AWS_H2_FRAME_F_END_HEADERS */
@@ -271,7 +261,7 @@ int aws_h2_frame_header_block_encode(
 /**
  * The process of encoding a frame looks like:
  * 1. Create a encoder object on the stack and initialize with aws_h2_frame_encoder_init
- * 2. Encode the header using aws_h2_frame_*_encode
+ * 2. Encode the frame using aws_h2_frame_*_encode
  */
 AWS_HTTP_API
 int aws_h2_frame_encoder_init(struct aws_h2_frame_encoder *encoder, struct aws_allocator *allocator);
@@ -282,7 +272,7 @@ void aws_h2_frame_encoder_clean_up(struct aws_h2_frame_encoder *encoder);
 AWS_HTTP_API
 int aws_h2_encode_frame(
     struct aws_h2_frame_encoder *encoder,
-    struct aws_h2_frame_header *frame_header,
+    struct aws_h2_frame_base *frame,
     struct aws_byte_buf *output);
 
 AWS_HTTP_API

--- a/tests/fuzz/fuzz_h2_decoder_correct.c
+++ b/tests/fuzz/fuzz_h2_decoder_correct.c
@@ -139,7 +139,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_data frame;
                 aws_h2_frame_data_init(&frame, allocator);
 
-                s_generate_stream_id(&input, &frame.header.stream_id);
+                s_generate_stream_id(&input, &frame.base.stream_id);
                 aws_byte_cursor_read_u8(&input, &frame.pad_length);
 
                 uint32_t payload_len = input.len;
@@ -157,7 +157,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_headers frame;
                 aws_h2_frame_headers_init(&frame, allocator);
 
-                s_generate_stream_id(&input, &frame.header.stream_id);
+                s_generate_stream_id(&input, &frame.base.stream_id);
 
                 s_generate_header_block(&input, &frame.header_block);
 
@@ -169,7 +169,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_priority frame;
                 aws_h2_frame_priority_init(&frame, allocator);
 
-                s_generate_stream_id(&input, &frame.header.stream_id);
+                s_generate_stream_id(&input, &frame.base.stream_id);
 
                 uint32_t stream_dependency = 0;
                 aws_byte_cursor_read_be32(&input, &stream_dependency);
@@ -187,7 +187,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_rst_stream frame;
                 aws_h2_frame_rst_stream_init(&frame, allocator);
 
-                s_generate_stream_id(&input, &frame.header.stream_id);
+                s_generate_stream_id(&input, &frame.base.stream_id);
 
                 aws_byte_cursor_read_be32(&input, &frame.error_code);
 
@@ -216,7 +216,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_push_promise frame;
                 aws_h2_frame_push_promise_init(&frame, allocator);
 
-                s_generate_stream_id(&input, &frame.header.stream_id);
+                s_generate_stream_id(&input, &frame.base.stream_id);
 
                 s_generate_header_block(&input, &frame.header_block);
 
@@ -262,7 +262,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 aws_h2_frame_window_update_init(&frame, allocator);
 
                 /* WINDOW_UPDATE's stream-id can be zero or non-zero */
-                aws_byte_cursor_read_be32(&input, &frame.header.stream_id);
+                aws_byte_cursor_read_be32(&input, &frame.base.stream_id);
 
                 aws_byte_cursor_read_be32(&input, &frame.window_size_increment);
 
@@ -278,7 +278,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_headers headers_frame;
                 aws_h2_frame_headers_init(&headers_frame, allocator);
 
-                headers_frame.header.stream_id = stream_id;
+                headers_frame.base.stream_id = stream_id;
 
                 aws_h2_frame_headers_encode(&headers_frame, &encoder, &frame_data);
                 aws_h2_frame_headers_clean_up(&headers_frame);
@@ -287,7 +287,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
                 struct aws_h2_frame_continuation continuation_frame;
                 aws_h2_frame_continuation_init(&continuation_frame, allocator);
 
-                continuation_frame.header.stream_id = stream_id;
+                continuation_frame.base.stream_id = stream_id;
                 s_generate_header_block(&input, &continuation_frame.header_block);
 
                 aws_h2_frame_continuation_encode(&continuation_frame, &encoder, &frame_data);

--- a/tests/test_h2_headers.c
+++ b/tests/test_h2_headers.c
@@ -83,7 +83,7 @@ static int s_header_test_before(struct aws_allocator *allocator, void *ctx) {
     fixture->decoder = aws_hpack_context_new(allocator, AWS_LS_HTTP_DECODER, NULL);
     ASSERT_NOT_NULL(fixture->decoder);
     ASSERT_SUCCESS(aws_h2_frame_headers_init(&fixture->headers_to_encode, allocator));
-    fixture->headers_to_encode.header.stream_id = 1;
+    fixture->headers_to_encode.base.stream_id = 1;
 
     ASSERT_SUCCESS(aws_byte_buf_init(&fixture->expected_encoding_buf, allocator, S_BUFFER_SIZE));
     ASSERT_SUCCESS(


### PR DESCRIPTION
I found it confusing that the term "header" didn't always refer to HTTP headers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
