### PR TITLE
HTTP/2 queues outgoing frames

### DIFF
--- a/include/aws/http/private/connection_impl.h
+++ b/include/aws/http/private/connection_impl.h
@@ -39,6 +39,9 @@ struct aws_http_connection_system_vtable {
 struct aws_http_connection_vtable {
     struct aws_channel_handler_vtable channel_handler_vtable;
 
+    /* This is a callback I wish was in aws_channel_handler_vtable. */
+    void (*on_channel_handler_installed)(struct aws_channel_handler *handler, struct aws_channel_slot *slot);
+
     struct aws_http_stream *(*make_request)(
         struct aws_http_connection *client_connection,
         const struct aws_http_make_request_options *options);

--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -89,8 +89,12 @@ struct aws_http_connection *aws_http_connection_new_http2_client(
     struct aws_allocator *allocator,
     size_t initial_window_size);
 
-/* Enqueue outgoing frame
- * Connection takes ownership of frame. */
+/**
+ * Enqueue outgoing frame.
+ * Connection takes ownership of frame.
+ * Frames are sent into FIFO order.
+ * Do not enqueue DATA frames, these are sent by other means when the frame queue is empty.
+ */
 AWS_HTTP_API
 void aws_h2_connection_enqueue_outgoing_frame(struct aws_h2_connection *connection, struct aws_h2_frame_base *frame);
 

--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -77,6 +77,8 @@ struct aws_h2_connection {
     } synced_data;
 };
 
+/* Private functions called from tests... */
+
 AWS_EXTERN_C_BEGIN
 
 AWS_HTTP_API
@@ -89,15 +91,16 @@ struct aws_http_connection *aws_http_connection_new_http2_client(
     struct aws_allocator *allocator,
     size_t initial_window_size);
 
+AWS_EXTERN_C_END
+
+/* Private functions called from multiple .c files... */
+
 /**
  * Enqueue outgoing frame.
  * Connection takes ownership of frame.
  * Frames are sent into FIFO order.
  * Do not enqueue DATA frames, these are sent by other means when the frame queue is empty.
  */
-AWS_HTTP_API
 void aws_h2_connection_enqueue_outgoing_frame(struct aws_h2_connection *connection, struct aws_h2_frame_base *frame);
-
-AWS_EXTERN_C_END
 
 #endif /* AWS_HTTP_H2_CONNECTION_H */

--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -44,7 +44,7 @@ struct aws_h2_connection {
 
         /* Maps stream-id to aws_h2_stream*.
          * Contains all streams in the open, reserved, and half-closed states (terms from RFC-7540 5.1).
-         * Once a stream is closed, it is removed from this map. */
+         * Once a stream enters closed state, it is removed from this map. */
         struct aws_hash_table active_streams_map;
 
         /* List using aws_h2_stream.node.

--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -74,6 +74,10 @@ enum aws_h2_settings {
     AWS_H2_SETTINGS_END_RANGE, /* End of known values */
 };
 
+/* This magic string must be the very first thing a client sends to the server.
+ * See RFC-7540 3.5 - HTTP/2 Connection Preface */
+extern const struct aws_byte_cursor aws_h2_connection_preface_client_string;
+
 /* RFC-7541 2.4 */
 enum aws_h2_header_field_hpack_behavior {
     AWS_H2_HEADER_BEHAVIOR_SAVE,

--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -111,6 +111,7 @@ struct aws_h2_frame_header_block {
 struct aws_h2_frame_base {
     uint8_t type; /* aws_h2_frame_type */
     uint32_t stream_id;
+    struct aws_linked_list_node node;
 };
 
 /* Represents a DATA frame */
@@ -238,6 +239,10 @@ struct aws_h2_frame_encoder {
 };
 
 AWS_EXTERN_C_BEGIN
+
+/* #TODO: remove each frame type's specific clean_up() function from API */
+AWS_HTTP_API
+void aws_h2_frame_clean_up(struct aws_h2_frame_base *frame);
 
 AWS_HTTP_API
 const char *aws_h2_frame_type_to_str(enum aws_h2_frame_type type);

--- a/include/aws/http/private/h2_stream.h
+++ b/include/aws/http/private/h2_stream.h
@@ -52,9 +52,9 @@ struct aws_h2_stream {
 
     /* Only the event-loop thread may touch this data */
     struct {
-        bool expects_continuation;
         enum aws_h2_stream_state state;
         uint64_t window_size; /* #TODO try to figure out how this actually works, and then implement it */
+        struct aws_http_message *outgoing_message;
     } thread_data;
 
     /* Any thread may touch this data, but the lock must be held */
@@ -64,18 +64,15 @@ struct aws_h2_stream {
     } synced_data;
 };
 
-struct aws_h2_stream;
-
-AWS_EXTERN_C_BEGIN
-
-AWS_HTTP_API
 const char *aws_h2_stream_state_to_str(enum aws_h2_stream_state state);
 
-AWS_HTTP_API
 struct aws_h2_stream *aws_h2_stream_new_request(
     struct aws_http_connection *client_connection,
     const struct aws_http_make_request_options *options);
 
-AWS_EXTERN_C_END
+enum aws_h2_stream_state aws_h2_stream_get_state(const struct aws_h2_stream *stream);
+
+/* Connection is ready to send frames from stream now */
+int aws_h2_stream_on_activated(struct aws_h2_stream *stream, bool *out_has_outgoing_data);
 
 #endif /* AWS_HTTP_H2_STREAM_H */

--- a/source/connection.c
+++ b/source/connection.c
@@ -194,11 +194,8 @@ static struct aws_http_connection *s_connection_new(
         goto error;
     }
 
-    connection->channel_slot = connection_slot;
-
-    /* Success! Acquire a hold on the channel to prevent its destruction until the user has
-     * given the go-ahead via aws_http_connection_release() */
-    aws_channel_acquire_hold(channel);
+    /* Success! Inform connection that installation is complete */
+    connection->vtable->on_channel_handler_installed(&connection->channel_handler, connection_slot);
 
     return connection;
 

--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -144,6 +144,11 @@ static void s_stop(
     }
 }
 
+static void s_shutdown_due_to_write_err(struct aws_h2_connection *connection, int error_code) {
+    AWS_PRECONDITION(error_code);
+    s_stop(connection, false /*stop_reading*/, true /*stop_writing*/, true /*schedule_shutdown*/, error_code);
+}
+
 /* Common new() logic for server & client */
 static struct aws_h2_connection *s_connection_new(
     struct aws_allocator *alloc,
@@ -175,6 +180,9 @@ static struct aws_h2_connection *s_connection_new(
 
     connection->synced_data.is_open = true;
     aws_linked_list_init(&connection->synced_data.pending_stream_list);
+
+    aws_linked_list_init(&connection->thread_data.outgoing_streams_list);
+    aws_linked_list_init(&connection->thread_data.outgoing_frames_queue);
 
     if (aws_mutex_init(&connection->synced_data.lock)) {
         CONNECTION_LOGF(
@@ -244,6 +252,8 @@ struct aws_http_connection *aws_http_connection_new_http2_client(
 
     connection->base.client_data = &connection->base.client_or_server_data.client;
 
+    /* #TODO immediately send connection preface string and settings */
+
     return &connection->base;
 }
 
@@ -256,7 +266,15 @@ static void s_handler_destroy(struct aws_channel_handler *handler) {
         !aws_hash_table_is_valid(&connection->thread_data.active_streams_map) ||
         aws_hash_table_get_entry_count(&connection->thread_data.active_streams_map) == 0);
 
+    AWS_ASSERT(aws_linked_list_empty(&connection->thread_data.outgoing_streams_list));
     AWS_ASSERT(aws_linked_list_empty(&connection->synced_data.pending_stream_list));
+
+    /* Clean up any unsent frames */
+    struct aws_linked_list *outgoing_frames_queue = &connection->thread_data.outgoing_frames_queue;
+    while (!aws_linked_list_empty(outgoing_frames_queue)) {
+        struct aws_linked_list_node *node = aws_linked_list_pop_front(outgoing_frames_queue);
+        aws_h2_frame_clean_up(AWS_CONTAINER_OF(node, struct aws_h2_frame_base, node));
+    }
 
     aws_h2_decoder_destroy(connection->thread_data.decoder);
     aws_h2_frame_encoder_clean_up(&connection->thread_data.encoder);
@@ -265,7 +283,214 @@ static void s_handler_destroy(struct aws_channel_handler *handler) {
     aws_mem_release(connection->base.alloc, connection);
 }
 
-static void s_stream_complete(struct aws_h2_stream *stream, int error_code) {
+void aws_h2_connection_enqueue_outgoing_frame(struct aws_h2_connection *connection, struct aws_h2_frame_base *frame) {
+    /* DATA frames are not queued. We only send DATA frames when the frame queue is empty */
+    AWS_PRECONDITION(frame->type != AWS_H2_FRAME_T_DATA);
+    AWS_PRECONDITION(aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel));
+
+    aws_linked_list_push_back(&connection->thread_data.outgoing_frames_queue, &frame->node);
+}
+
+static void s_on_channel_write_complete(
+    struct aws_channel *channel,
+    struct aws_io_message *message,
+    int err_code,
+    void *user_data) {
+
+    (void)message;
+    struct aws_h2_connection *connection = user_data;
+
+    if (err_code) {
+        CONNECTION_LOGF(ERROR, connection, "Message did not write to network, error %s", aws_error_name(err_code));
+        s_shutdown_due_to_write_err(connection, err_code);
+        return;
+    }
+
+    CONNECTION_LOG(TRACE, connection, "Message finished writing to network. Rescheduling outgoing frame task");
+
+    /* To avoid wasting memory, we only want ONE of our written aws_io_messages in the channel at a time.
+     * Therefore, we wait until it's written to the network before trying to send another
+     * by running the outgoing-frame-task again.
+     *
+     * We also want to share the network with other channels.
+     * Therefore, when the write completes, we SCHEDULE the outgoing-frame-task
+     * to run again instead of calling the function directly.
+     * This way, if the message completes synchronously,
+     * we're not hogging the network by writing message after message in a tight loop */
+    aws_channel_schedule_task_now(channel, &connection->outgoing_frames_task);
+}
+
+static void s_outgoing_frames_task(struct aws_channel_task *task, void *arg, enum aws_task_status status) {
+    if (status != AWS_TASK_STATUS_RUN_READY) {
+        return;
+    }
+
+    struct aws_h2_connection *connection = arg;
+    struct aws_channel_slot *channel_slot = connection->base.channel_slot;
+    struct aws_linked_list *outgoing_frames_queue = &connection->thread_data.outgoing_frames_queue;
+    struct aws_linked_list *outgoing_streams_list = &connection->thread_data.outgoing_streams_list;
+
+    AWS_PRECONDITION(aws_channel_thread_is_callers_thread(channel_slot->channel));
+    AWS_PRECONDITION(connection->thread_data.is_outgoing_frames_task_active);
+
+    /* If there is nothing to send, then end the task immediately */
+    if (aws_linked_list_empty(outgoing_frames_queue) && aws_linked_list_empty(outgoing_streams_list)) {
+        CONNECTION_LOG(TRACE, connection, "Outgoing frames task stopped, nothing to send at this time");
+        connection->thread_data.is_outgoing_frames_task_active = false;
+        return;
+    }
+
+    /* Acquire aws_io_message, that we will attempt to fill up */
+    struct aws_io_message *msg = aws_channel_slot_acquire_max_message_for_write(channel_slot);
+    if (AWS_UNLIKELY(!msg)) {
+        CONNECTION_LOG(ERROR, connection, "Failed to acquire message from pool, closing connection.");
+        goto error;
+    }
+
+    /* Set up callback so we can send another message when this one completes */
+    msg->on_completion = s_on_channel_write_complete;
+    msg->user_data = connection;
+
+    CONNECTION_LOGF(
+        TRACE,
+        connection,
+        "Outgoing frames task acquired message with %zu bytes available",
+        msg->message_data.capacity - msg->message_data.len);
+
+    /* Track number of frames encoded, just used for logging */
+    size_t num_frames_encoded = 0;
+
+    /* Write as many frames from outgoing_frames_queue as possible. */
+    while (!aws_linked_list_empty(outgoing_frames_queue)) {
+        struct aws_linked_list_node *frame_node = aws_linked_list_front(outgoing_frames_queue);
+        struct aws_h2_frame_base *frame = AWS_CONTAINER_OF(frame_node, struct aws_h2_frame_base, node);
+
+        /* #TODO actual functionality to query min required space for a frame */
+        const size_t min_required_bytes = 1024;
+        const size_t available_bytes = msg->message_data.capacity - msg->message_data.len;
+        if (available_bytes < min_required_bytes) {
+            if (msg->message_data.len == 0) {
+                /* We're in trouble if an empty message isn't big enough for this frame to do any work with */
+                CONNECTION_LOGF(
+                    ERROR,
+                    connection,
+                    "Cannot encode %s frame requiring %zu bytes, max available space is %zu",
+                    aws_h2_frame_type_to_str(frame->type),
+                    min_required_bytes,
+                    available_bytes);
+                aws_raise_error(AWS_ERROR_INVALID_STATE);
+                goto error;
+            }
+
+            CONNECTION_LOG(TRACE, connection, "Outgoing frames task filled message, and has more frames to send later");
+            goto done_encoding;
+        }
+
+        /* #TODO some way for frame to say it's not done yet.
+         * Necessary for HEADERS that will split across CONTINUATION frames */
+        if (aws_h2_encode_frame(&connection->thread_data.encoder, frame, &msg->message_data)) {
+            CONNECTION_LOGF(
+                ERROR,
+                connection,
+                "Error encoding frame of type %s: %s",
+                aws_h2_frame_type_to_str(frame->type),
+                aws_error_name(aws_last_error()));
+            goto error;
+        }
+
+        /* Done encoding frame, pop from queue and cleanup*/
+        aws_linked_list_remove(frame_node);
+        aws_h2_frame_clean_up(frame);
+
+        num_frames_encoded++;
+    }
+
+    /* Write as many DATA frames from outgoing_streams_list as possible.
+     * We simply round-robin through available streams, instead of using stream priority.
+     *
+     * Respecting priority is not required (RFC-7540 5.3), so we're ignoring it for now. This also keeps use safe
+     * from priority DOS attacks: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513
+     */
+    while (!aws_linked_list_empty(outgoing_streams_list)) {
+        num_frames_encoded++;
+
+        /* #TODO actually encode DATA frames.
+         * It will go something like:
+         * If there's not enough room in msg to bother encoding anything: goto done_encoding.
+         * Encode a DATA frame
+         * - It will write as much data as will fit in msg, and as much data as body_stream will give us
+         * - Encoder will go back and edit frame length to fit what we actually encoded.
+         * - Encoder will go back and edit END_STREAM flag if we reached the end of the body_stream.
+         *
+         * If stream has sent all data:
+         * - Remove stream from outgoing_streams_list
+         * - Stream is complete if it is also done receiving (weird edge case, but theoretically possible)
+         * Else stream has not sent all data:
+         * - Move stream to back of outgoing_streams_list ("round-robin" DATA frames from available streams)
+         */
+        CONNECTION_LOG(ERROR, connection, "DATA frames not supported yet");
+        aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+        goto error;
+    }
+
+done_encoding:
+    if (msg->message_data.len) {
+        /* Write message to channel.
+         * outgoing_frames_task will resume when message completes. */
+        CONNECTION_LOGF(
+            TRACE,
+            connection,
+            "Outgoing frames task sending message of size %zu containing ~%zu frames",
+            msg->message_data.len,
+            num_frames_encoded);
+
+        if (aws_channel_slot_send_message(channel_slot, msg, AWS_CHANNEL_DIR_WRITE)) {
+            CONNECTION_LOGF(
+                ERROR,
+                connection,
+                "Failed to send channel message: %s. Closing connection.",
+                aws_error_name(aws_last_error()));
+
+            goto error;
+        }
+    } else {
+        /* Message is empty, warn that no work is being done and reschedule the task to try again next tick.
+         * It's likely that body isn't ready, so body streaming function has no data to write yet.
+         * If this scenario turns out to be common we should implement a "pause" feature. */
+        CONNECTION_LOG(WARN, connection, "Outgoing frames task sent no data, will try again next tick.");
+
+        aws_mem_release(msg->allocator, msg);
+
+        aws_channel_schedule_task_now(channel_slot->channel, task);
+    }
+    return;
+
+error:;
+    int error_code = aws_last_error();
+
+    if (msg) {
+        aws_mem_release(msg->allocator, msg);
+    }
+
+    s_shutdown_due_to_write_err(connection, error_code);
+}
+
+/* If the outgoing-frames-task isn't scheduled, run it immediately. */
+static void s_try_write_outgoing_frames(struct aws_h2_connection *connection) {
+    AWS_PRECONDITION(aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel));
+
+    if (connection->thread_data.is_outgoing_frames_task_active) {
+        return;
+    }
+
+    CONNECTION_LOG(TRACE, connection, "Starting outgoing frames task");
+    connection->thread_data.is_outgoing_frames_task_active = true;
+    s_outgoing_frames_task(&connection->outgoing_frames_task, connection, AWS_TASK_STATUS_RUN_READY);
+}
+
+static void s_stream_complete(struct aws_h2_connection *connection, struct aws_h2_stream *stream, int error_code) {
+    AWS_PRECONDITION(aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel));
+
     /* Nice logging */
     if (error_code) {
         AWS_H2_STREAM_LOGF(
@@ -278,6 +503,12 @@ static void s_stream_complete(struct aws_h2_stream *stream, int error_code) {
         AWS_H2_STREAM_LOG(DEBUG, stream, "Server stream complete");
     }
 
+    /* Remove stream from active_streams_map and outgoing_stream_list (if it was in them at all) */
+    aws_hash_table_remove(&connection->thread_data.active_streams_map, stream, NULL, NULL);
+    if (stream->node.next) {
+        aws_linked_list_remove(&stream->node);
+    }
+
     /* Invoke callback */
     if (stream->base.on_complete) {
         stream->base.on_complete(&stream->base, error_code, stream->base.user_data);
@@ -288,18 +519,29 @@ static void s_stream_complete(struct aws_h2_stream *stream, int error_code) {
 }
 
 static void s_activate_stream(struct aws_h2_connection *connection, struct aws_h2_stream *stream) {
+    AWS_PRECONDITION(aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel));
+
     /* #TODO: don't exceed peer's max-concurrent-streams setting */
 
     if (aws_hash_table_put(
             &connection->thread_data.active_streams_map, (void *)(size_t)stream->base.id, stream, NULL)) {
+        AWS_H2_STREAM_LOG(ERROR, stream, "Failed inserting stream into map");
         goto error;
     }
 
-    /* #TODO: start encoding this stream's frames */
+    bool has_outgoing_data = false;
+    if (aws_h2_stream_on_activated(stream, &has_outgoing_data)) {
+        goto error;
+    }
+
+    if (has_outgoing_data) {
+        aws_linked_list_push_back(&connection->thread_data.outgoing_streams_list, &stream->node);
+    }
 
     return;
 error:
-    s_stream_complete(stream, aws_last_error());
+    /* If the stream got into any datastructures, s_stream_complete() will remove it */
+    s_stream_complete(connection, stream, aws_last_error());
 }
 
 /* Perform on-thread work that is triggered by calls to the connection/stream API */
@@ -331,6 +573,10 @@ static void s_cross_thread_work_task(struct aws_channel_task *task, void *arg, e
     }
 
     /* #TODO: process stuff from other API calls (ex: window-updates) */
+
+    /* It's likely that frames were queued while processing cross-thread work.
+     * If so, try writing them now */
+    s_try_write_outgoing_frames(connection);
 }
 
 static struct aws_http_stream *s_connection_make_request(
@@ -339,7 +585,8 @@ static struct aws_http_stream *s_connection_make_request(
 
     struct aws_h2_connection *connection = AWS_CONTAINER_OF(client_connection, struct aws_h2_connection, base);
 
-    /* #TODO: http/2-ify the request (ex: add ":method" header). Should we mutate a copy or the original? */
+    /* #TODO: http/2-ify the request (ex: add ":method" header). Should we mutate a copy or the original? Validate?
+     *  Or just pass pointer to headers struct and let encoder transform it while encoding? */
 
     struct aws_h2_stream *stream = aws_h2_stream_new_request(client_connection, options);
     if (!stream) {
@@ -466,7 +713,7 @@ static int s_handler_shutdown(
             aws_hash_iter_delete(&stream_iter, true);
             aws_hash_iter_next(&stream_iter);
 
-            s_stream_complete(stream, AWS_ERROR_HTTP_CONNECTION_CLOSED);
+            s_stream_complete(connection, stream, AWS_ERROR_HTTP_CONNECTION_CLOSED);
         }
 
         /* It's OK to access synced_data.pending_stream_list without holding the lock because
@@ -474,7 +721,7 @@ static int s_handler_shutdown(
         while (!aws_linked_list_empty(&connection->synced_data.pending_stream_list)) {
             struct aws_linked_list_node *node = aws_linked_list_pop_front(&connection->synced_data.pending_stream_list);
             struct aws_h2_stream *stream = AWS_CONTAINER_OF(node, struct aws_h2_stream, node);
-            s_stream_complete(stream, AWS_ERROR_HTTP_CONNECTION_CLOSED);
+            s_stream_complete(connection, stream, AWS_ERROR_HTTP_CONNECTION_CLOSED);
         }
     }
 

--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -292,7 +292,6 @@ static void s_handler_destroy(struct aws_channel_handler *handler) {
 }
 
 void aws_h2_connection_enqueue_outgoing_frame(struct aws_h2_connection *connection, struct aws_h2_frame_base *frame) {
-    /* DATA frames are not queued. We only send DATA frames when the frame queue is empty */
     AWS_PRECONDITION(frame->type != AWS_H2_FRAME_T_DATA);
     AWS_PRECONDITION(aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel));
 

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -31,10 +31,6 @@ static const size_t s_scratch_space_size = 9;
 /* Stream ids & dependencies should only write the bottom 31 bits */
 static const uint32_t s_31_bit_mask = UINT32_MAX >> 1;
 
-/* First 24 bytes sent by client must be this string (RFC-7540 3.5) */
-static const struct aws_byte_cursor s_connection_preface_string =
-    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
-
 #define DECODER_LOGF(level, decoder, text, ...)                                                                        \
     AWS_LOGF_##level(AWS_LS_HTTP_DECODER, "id=%p " text, (decoder)->logging_id, __VA_ARGS__)
 #define DECODER_LOG(level, decoder, text) DECODER_LOGF(level, decoder, "%s", text)
@@ -217,7 +213,7 @@ struct aws_h2_decoder *aws_h2_decoder_new(struct aws_h2_decoder_params *params) 
 
     if (decoder->is_server && !params->skip_connection_preface) {
         decoder->state = &s_state_connection_preface_string;
-        decoder->connection_preface_cursor = s_connection_preface_string;
+        decoder->connection_preface_cursor = aws_h2_connection_preface_client_string;
     } else {
         decoder->state = &s_state_prefix;
     }

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -1036,6 +1036,8 @@ static int s_state_fn_header_block_entry(struct aws_h2_decoder *decoder, struct 
      * - can't have unrecognized/invalid pseudo-headers
      * These make the message "malformed", which is a STREAM error, not PROTOCOL error, not sure how to handle that */
 
+    /* #TODO Cookie headers must be concatenated into single delivery RFC-7540 8.1.2.5 */
+
     if (result.type == AWS_HPACK_DECODE_T_HEADER_FIELD) {
         const struct aws_hpack_decoded_header_field *field = &result.data.header_field;
 

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -946,6 +946,53 @@ compression_error:
     return aws_raise_error(AWS_ERROR_HTTP_COMPRESSION);
 }
 
+void aws_h2_frame_clean_up(struct aws_h2_frame_base *frame) {
+    switch (frame->type) {
+        case AWS_H2_FRAME_T_DATA:
+            aws_h2_frame_data_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_data, base));
+            break;
+
+        case AWS_H2_FRAME_T_HEADERS:
+            aws_h2_frame_headers_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_headers, base));
+            break;
+
+        case AWS_H2_FRAME_T_PRIORITY:
+            aws_h2_frame_priority_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_priority, base));
+            break;
+
+        case AWS_H2_FRAME_T_RST_STREAM:
+            aws_h2_frame_rst_stream_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_rst_stream, base));
+            break;
+
+        case AWS_H2_FRAME_T_SETTINGS:
+            aws_h2_frame_settings_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_settings, base));
+            break;
+
+        case AWS_H2_FRAME_T_PUSH_PROMISE:
+            aws_h2_frame_push_promise_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_push_promise, base));
+            break;
+
+        case AWS_H2_FRAME_T_PING:
+            aws_h2_frame_ping_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_ping, base));
+            break;
+
+        case AWS_H2_FRAME_T_GOAWAY:
+            aws_h2_frame_goaway_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_goaway, base));
+            break;
+
+        case AWS_H2_FRAME_T_WINDOW_UPDATE:
+            aws_h2_frame_window_update_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_window_update, base));
+            break;
+
+        case AWS_H2_FRAME_T_CONTINUATION:
+            aws_h2_frame_continuation_clean_up(AWS_CONTAINER_OF(frame, struct aws_h2_frame_continuation, base));
+            break;
+
+        default:
+            AWS_ASSERT(0);
+    }
+}
+
 int aws_h2_encode_frame(
     struct aws_h2_frame_encoder *encoder,
     struct aws_h2_frame_base *frame,

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -27,6 +27,9 @@
  *        we send that code in the GOAWAY, or always treat encoder errors as AWS_H2_ERR_INTERNAL?
  *        Like, you're only supposed to inform peer of errors that were their fault, right? */
 
+const struct aws_byte_cursor aws_h2_connection_preface_client_string =
+    AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
+
 /* Stream ids & dependencies should only write the bottom 31 bits */
 static const uint32_t s_31_bit_mask = UINT32_MAX >> 1;
 static const uint32_t s_u32_top_bit_mask = UINT32_MAX << 31;

--- a/source/h2_stream.c
+++ b/source/h2_stream.c
@@ -125,6 +125,7 @@ static struct aws_h2_frame_headers *s_new_headers_frame(
         goto error_init;
     }
 
+    /* #TODO headers frame needs to respect max frame size, and use CONTINUATION */
     const size_t num_headers = aws_http_message_get_header_count(message);
     for (size_t i = 0; i < num_headers; ++i) {
         struct aws_h2_frame_header_field header_field = {

--- a/source/h2_stream.c
+++ b/source/h2_stream.c
@@ -54,10 +54,8 @@ static struct aws_h2_connection *s_get_h2_connection(const struct aws_h2_stream 
     return AWS_CONTAINER_OF(stream->base.owning_connection, struct aws_h2_connection, base);
 }
 
-static bool s_is_on_channel_thread(const struct aws_h2_stream *stream) {
-    const struct aws_h2_connection *connection = s_get_h2_connection(stream);
-    return aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel);
-}
+#define AWS_PRECONDITION_ON_CHANNEL_THREAD(STREAM)                                                                     \
+    AWS_PRECONDITION(aws_channel_thread_is_callers_thread(s_get_h2_connection(STREAM)->base.channel_slot->channel))
 
 struct aws_h2_stream *aws_h2_stream_new_request(
     struct aws_http_connection *client_connection,
@@ -110,7 +108,7 @@ static void s_stream_destroy(struct aws_http_stream *stream_base) {
 }
 
 enum aws_h2_stream_state aws_h2_stream_get_state(const struct aws_h2_stream *stream) {
-    AWS_PRECONDITION(s_is_on_channel_thread(stream));
+    AWS_PRECONDITION_ON_CHANNEL_THREAD(stream);
     return stream->thread_data.state;
 }
 
@@ -157,7 +155,7 @@ error_alloc:
 }
 
 int aws_h2_stream_on_activated(struct aws_h2_stream *stream, bool *out_has_outgoing_data) {
-    AWS_PRECONDITION(s_is_on_channel_thread(stream));
+    AWS_PRECONDITION_ON_CHANNEL_THREAD(stream);
 
     struct aws_h2_connection *connection = s_get_h2_connection(stream);
 

--- a/source/h2_stream.c
+++ b/source/h2_stream.c
@@ -50,9 +50,14 @@ const char *aws_h2_stream_state_to_str(enum aws_h2_stream_state state) {
     }
 }
 
-/***********************************************************************************************************************
- * Public API
- **********************************************************************************************************************/
+static struct aws_h2_connection *s_get_h2_connection(const struct aws_h2_stream *stream) {
+    return AWS_CONTAINER_OF(stream->base.owning_connection, struct aws_h2_connection, base);
+}
+
+static bool s_is_on_channel_thread(const struct aws_h2_stream *stream) {
+    const struct aws_h2_connection *connection = s_get_h2_connection(stream);
+    return aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel);
+}
 
 struct aws_h2_stream *aws_h2_stream_new_request(
     struct aws_http_connection *client_connection,
@@ -60,6 +65,7 @@ struct aws_h2_stream *aws_h2_stream_new_request(
     AWS_PRECONDITION(client_connection);
     AWS_PRECONDITION(options);
 
+    /* #TODO optimization: don't make use of atomic here. have connection assign from connection->synced_data */
     uint32_t stream_id = aws_http_connection_get_next_stream_id(client_connection);
     if (stream_id == 0) {
         return NULL;
@@ -67,7 +73,6 @@ struct aws_h2_stream *aws_h2_stream_new_request(
 
     struct aws_h2_stream *stream = aws_mem_calloc(client_connection->alloc, 1, sizeof(struct aws_h2_stream));
     if (!stream) {
-        /* stream id exhausted error was already raised*/
         return NULL;
     }
 
@@ -87,15 +92,97 @@ struct aws_h2_stream *aws_h2_stream_new_request(
 
     /* Init H2 specific stuff */
     stream->thread_data.state = AWS_H2_STREAM_STATE_IDLE;
-    aws_linked_list_node_reset(&stream->node);
+    stream->thread_data.outgoing_message = options->request;
+    aws_http_message_acquire(stream->thread_data.outgoing_message);
 
     return stream;
 }
+
 static void s_stream_destroy(struct aws_http_stream *stream_base) {
     AWS_PRECONDITION(stream_base);
     struct aws_h2_stream *stream = AWS_CONTAINER_OF(stream_base, struct aws_h2_stream, base);
 
     AWS_H2_STREAM_LOG(DEBUG, stream, "Destroying stream");
 
+    aws_http_message_release(stream->thread_data.outgoing_message);
+
     aws_mem_release(stream->base.alloc, stream);
+}
+
+enum aws_h2_stream_state aws_h2_stream_get_state(const struct aws_h2_stream *stream) {
+    AWS_PRECONDITION(s_is_on_channel_thread(stream));
+    return stream->thread_data.state;
+}
+
+static struct aws_h2_frame_headers *s_new_headers_frame(
+    struct aws_allocator *alloc,
+    const struct aws_http_message *message) {
+
+    struct aws_h2_frame_headers *headers_frame = aws_mem_calloc(alloc, 1, sizeof(struct aws_h2_frame_headers));
+    if (!headers_frame) {
+        goto error_alloc;
+    }
+
+    if (aws_h2_frame_headers_init(headers_frame, alloc)) {
+        goto error_init;
+    }
+
+    const size_t num_headers = aws_http_message_get_header_count(message);
+    for (size_t i = 0; i < num_headers; ++i) {
+        struct aws_h2_frame_header_field header_field = {
+            /* #TODO: let user specify hpack behavior */
+            .hpack_behavior = AWS_H2_HEADER_BEHAVIOR_SAVE,
+        };
+
+        aws_http_message_get_header(message, &header_field.header, i);
+        if (aws_array_list_push_back(&headers_frame->header_block.header_fields, &header_field)) {
+            goto error_push_back;
+        }
+    }
+
+    headers_frame->end_headers = true;
+
+    if (!aws_http_message_get_body_stream(message)) {
+        headers_frame->end_stream = true;
+    }
+
+    return headers_frame;
+
+error_push_back:
+    aws_h2_frame_clean_up(&headers_frame->base);
+error_init:
+    aws_mem_release(alloc, headers_frame);
+error_alloc:
+    return NULL;
+}
+
+int aws_h2_stream_on_activated(struct aws_h2_stream *stream, bool *out_has_outgoing_data) {
+    AWS_PRECONDITION(s_is_on_channel_thread(stream));
+
+    struct aws_h2_connection *connection = s_get_h2_connection(stream);
+
+    /* Create HEADERS frame */
+    struct aws_h2_frame_headers *headers_frame =
+        s_new_headers_frame(stream->base.alloc, stream->thread_data.outgoing_message);
+    if (!headers_frame) {
+        AWS_H2_STREAM_LOGF(ERROR, stream, "Failed to create HEADERS frame: %s", aws_error_name(aws_last_error()));
+        goto error;
+    }
+
+    if (aws_http_message_get_body_stream(stream->thread_data.outgoing_message)) {
+        /* If stream has DATA to send, put it in the outgoing_streams_list, and we'll send data later */
+        stream->thread_data.state = AWS_H2_STREAM_STATE_OPEN;
+        *out_has_outgoing_data = true;
+    } else {
+        /* If stream has no body, then HEADERS frame marks the end of outgoing data */
+        headers_frame->end_stream = true;
+        stream->thread_data.state = AWS_H2_STREAM_STATE_HALF_CLOSED_LOCAL;
+        *out_has_outgoing_data = false;
+    }
+
+    aws_h2_connection_enqueue_outgoing_frame(connection, &headers_frame->base);
+    return AWS_OP_SUCCESS;
+
+error:
+    return AWS_OP_ERR;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,6 +300,7 @@ add_h2_decoder_test_set(h2_decoder_err_bad_preface_from_client_3)
 
 add_test_case(h2_client_sanity_check)
 add_test_case(h2_client_request_create)
+add_test_case(h2_client_connection_preface_sent)
 
 add_test_case(server_new_destroy)
 add_test_case(connection_setup_shutdown)

--- a/tests/proxy_test_helper.c
+++ b/tests/proxy_test_helper.c
@@ -263,11 +263,9 @@ int proxy_tester_create_testing_channel_connection(struct proxy_tester *tester) 
 
     struct aws_channel_slot *slot = aws_channel_slot_new(tester->testing_channel->channel);
     ASSERT_NOT_NULL(slot);
-    connection->channel_slot = slot;
     ASSERT_SUCCESS(aws_channel_slot_insert_end(tester->testing_channel->channel, slot));
     ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &connection->channel_handler));
-
-    aws_channel_acquire_hold(tester->testing_channel->channel);
+    connection->vtable->on_channel_handler_installed(&connection->channel_handler, slot);
 
     tester->client_connection = connection;
     testing_channel_drain_queued_tasks(tester->testing_channel);

--- a/tests/test_connection_monitor.c
+++ b/tests/test_connection_monitor.c
@@ -123,11 +123,9 @@ static int s_init_monitor_test(struct aws_allocator *allocator, struct aws_crt_s
 
     struct aws_channel_slot *slot = aws_channel_slot_new(s_test_context.test_channel.channel);
     ASSERT_NOT_NULL(slot);
-    connection->channel_slot = slot;
     ASSERT_SUCCESS(aws_channel_slot_insert_end(s_test_context.test_channel.channel, slot));
     ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &connection->channel_handler));
-
-    aws_channel_acquire_hold(s_test_context.test_channel.channel);
+    connection->vtable->on_channel_handler_installed(&connection->channel_handler, slot);
 
     s_test_context.connection = connection;
     testing_channel_drain_queued_tasks(&s_test_context.test_channel);

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -76,11 +76,9 @@ static int s_tester_init(struct tester *tester, struct aws_allocator *alloc) {
 
     struct aws_channel_slot *slot = aws_channel_slot_new(tester->testing_channel.channel);
     ASSERT_NOT_NULL(slot);
-    tester->connection->channel_slot = slot;
     ASSERT_SUCCESS(aws_channel_slot_insert_end(tester->testing_channel.channel, slot));
     ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &tester->connection->channel_handler));
-
-    aws_channel_acquire_hold(tester->testing_channel.channel);
+    tester->connection->vtable->on_channel_handler_installed(&tester->connection->channel_handler, slot);
 
     testing_channel_drain_queued_tasks(&tester->testing_channel);
 

--- a/tests/test_h1_server.c
+++ b/tests/test_h1_server.c
@@ -203,11 +203,10 @@ static int s_tester_init(struct aws_allocator *alloc) {
 
     struct aws_channel_slot *slot = aws_channel_slot_new(s_tester.testing_channel.channel);
     ASSERT_NOT_NULL(slot);
-    s_tester.server_connection->channel_slot = slot;
     ASSERT_SUCCESS(aws_channel_slot_insert_end(s_tester.testing_channel.channel, slot));
     ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &s_tester.server_connection->channel_handler));
-
-    aws_channel_acquire_hold(s_tester.testing_channel.channel);
+    s_tester.server_connection->vtable->on_channel_handler_installed(
+        &s_tester.server_connection->channel_handler, slot);
 
     testing_channel_drain_queued_tasks(&s_tester.testing_channel);
 
@@ -1487,11 +1486,9 @@ static int s_error_tester_init(struct aws_allocator *alloc, struct error_from_ca
 
     struct aws_channel_slot *slot = aws_channel_slot_new(tester->testing_channel.channel);
     ASSERT_NOT_NULL(slot);
-    tester->server_connection->channel_slot = slot;
     ASSERT_SUCCESS(aws_channel_slot_insert_end(tester->testing_channel.channel, slot));
     ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &tester->server_connection->channel_handler));
-
-    aws_channel_acquire_hold(tester->testing_channel.channel);
+    tester->server_connection->vtable->on_channel_handler_installed(&tester->server_connection->channel_handler, slot);
 
     testing_channel_drain_queued_tasks(&tester->testing_channel);
 

--- a/tests/test_h2_client.c
+++ b/tests/test_h2_client.c
@@ -47,8 +47,7 @@ static int s_tester_init(struct aws_allocator *alloc, void *ctx) {
         ASSERT_NOT_NULL(slot);
         ASSERT_SUCCESS(aws_channel_slot_insert_end(s_tester.testing_channel.channel, slot));
         ASSERT_SUCCESS(aws_channel_slot_set_handler(slot, &s_tester.connection->channel_handler));
-        s_tester.connection->channel_slot = slot;
-        aws_channel_acquire_hold(s_tester.testing_channel.channel);
+        s_tester.connection->vtable->on_channel_handler_installed(&s_tester.connection->channel_handler, slot);
     }
 
     testing_channel_drain_queued_tasks(&s_tester.testing_channel);

--- a/tests/test_h2_client.c
+++ b/tests/test_h2_client.c
@@ -101,3 +101,31 @@ TEST_CASE(h2_client_request_create) {
 
     return s_tester_clean_up();
 }
+
+/* Test that client automatically sends the HTTP/2 Connection Preface */
+TEST_CASE(h2_client_connection_preface_sent) {
+    ASSERT_SUCCESS(s_tester_init(allocator, ctx));
+
+    struct aws_byte_buf expected;
+    ASSERT_SUCCESS(aws_byte_buf_init(&expected, s_tester.alloc, 1024));
+
+    ASSERT_TRUE(aws_byte_buf_write_from_whole_cursor(&expected, aws_h2_connection_preface_client_string));
+
+    /* clang-format off */
+    uint8_t expected_settings[] = {
+        0x00, 0x00, 0x00,           /* Length (24) */
+        AWS_H2_FRAME_T_SETTINGS,    /* Type (8) */
+        0x00,                       /* Flags (8) */
+        0x00, 0x00, 0x00, 0x00,     /* Reserved (1) | Stream Identifier (31) */
+    };
+    /* clang-format on */
+
+    ASSERT_TRUE(aws_byte_buf_write(&expected, expected_settings, sizeof(expected_settings)));
+
+    ASSERT_SUCCESS(testing_channel_check_written_messages(
+        &s_tester.testing_channel, s_tester.alloc, aws_byte_cursor_from_buf(&expected)));
+
+    aws_byte_buf_clean_up(&expected);
+
+    return s_tester_clean_up();
+}


### PR DESCRIPTION
**EXPAND LARGE DIFFS**

High-Level algorithm is this:
- `outgoing_frames_queue` is simple FIFO queue, holds all frame-types EXCEPT DATA.
- `outgoing_streams_list` is list of streams that have data to send.
- Connection writes frames from queue until it's empty, then writes data frames from the streams in a round-robin manner.

Details:
- Grab the largest possible `aws_io_message` and stuff as many frames as possible into it.
- Don't send another `aws_io_message` until the previous one finishes writing (same behavior as HTTP/1).

There's still a bunch of work to do, but this is a checkpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
