### PR TITLE
Move stuff that's specific to h1 decoder into h1_decoder.h

### DIFF
--- a/include/aws/http/private/http_impl.h
+++ b/include/aws/http/private/http_impl.h
@@ -54,56 +54,6 @@ enum aws_http_status {
     AWS_HTTP_STATUS_304_NOT_MODIFIED = 304,
 };
 
-struct aws_http_decoded_header {
-    /* Name of the header. If the type is `AWS_HTTP_HEADER_NAME_UNKNOWN` then `name_data` must be parsed manually. */
-    enum aws_http_header_name name;
-
-    /* Raw buffer storing the header's name. */
-    struct aws_byte_cursor name_data;
-
-    /* Raw buffer storing the header's value. */
-    struct aws_byte_cursor value_data;
-
-    /* Raw buffer storing the entire header. */
-    struct aws_byte_cursor data;
-};
-
-/**
- * Called from `aws_h*_decode` when an http header has been received.
- * All pointers are strictly *read only*; any data that needs to persist must be copied out into user-owned memory.
- */
-typedef int(aws_http_decoder_on_header_fn)(const struct aws_http_decoded_header *header, void *user_data);
-
-/**
- * Called from `aws_h*_decode` when a portion of the http body has been received.
- * `finished` is true if this is the last section of the http body, and false if more body data is yet to be received.
- * All pointers are strictly *read only*; any data that needs to persist must be copied out into user-owned memory.
- */
-typedef int(aws_http_decoder_on_body_fn)(const struct aws_byte_cursor *data, bool finished, void *user_data);
-
-typedef int(aws_http_decoder_on_request_fn)(
-    enum aws_http_method method_enum,
-    const struct aws_byte_cursor *method_str,
-    const struct aws_byte_cursor *uri,
-    void *user_data);
-
-typedef int(aws_http_decoder_on_response_fn)(int status_code, void *user_data);
-
-typedef int(aws_http_decoder_done_fn)(void *user_data);
-
-struct aws_http_decoder_vtable {
-    aws_http_decoder_on_header_fn *on_header;
-    aws_http_decoder_on_body_fn *on_body;
-
-    /* Only needed for requests, can be NULL for responses. */
-    aws_http_decoder_on_request_fn *on_request;
-
-    /* Only needed for responses, can be NULL for requests. */
-    aws_http_decoder_on_response_fn *on_response;
-
-    aws_http_decoder_done_fn *on_done;
-};
-
 AWS_EXTERN_C_BEGIN
 
 AWS_HTTP_API void aws_http_fatal_assert_library_initialized(void);

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -74,7 +74,7 @@ static int s_decoder_on_request(
     const struct aws_byte_cursor *uri,
     void *user_data);
 static int s_decoder_on_response(int status_code, void *user_data);
-static int s_decoder_on_header(const struct aws_http_decoded_header *header, void *user_data);
+static int s_decoder_on_header(const struct aws_h1_decoded_header *header, void *user_data);
 static int s_decoder_on_body(const struct aws_byte_cursor *data, bool finished, void *user_data);
 static int s_decoder_on_done(void *user_data);
 static void s_reset_statistics(struct aws_channel_handler *handler);
@@ -102,7 +102,7 @@ static struct aws_http_connection_vtable s_h1_connection_vtable = {
     .update_window = s_connection_update_window,
 };
 
-static const struct aws_http_decoder_vtable s_h1_decoder_vtable = {
+static const struct aws_h1_decoder_vtable s_h1_decoder_vtable = {
     .on_request = s_decoder_on_request,
     .on_response = s_decoder_on_response,
     .on_header = s_decoder_on_header,
@@ -966,7 +966,7 @@ static int s_decoder_on_response(int status_code, void *user_data) {
     return AWS_OP_SUCCESS;
 }
 
-static int s_decoder_on_header(const struct aws_http_decoded_header *header, void *user_data) {
+static int s_decoder_on_header(const struct aws_h1_decoded_header *header, void *user_data) {
     struct h1_connection *connection = user_data;
     struct aws_h1_stream *incoming_stream = connection->thread_data.incoming_stream;
 

--- a/source/h1_decoder.c
+++ b/source/h1_decoder.c
@@ -53,7 +53,7 @@ struct aws_h1_decoder {
     void *logging_id;
 
     /* User callbacks and settings. */
-    struct aws_http_decoder_vtable vtable;
+    struct aws_h1_decoder_vtable vtable;
     bool is_decoding_requests;
     void *user_data;
 };
@@ -445,7 +445,7 @@ static int s_linestate_header(struct aws_h1_decoder *decoder, struct aws_byte_cu
 
     struct aws_byte_cursor value = aws_strutil_trim_http_whitespace(splits[1]);
 
-    struct aws_http_decoded_header header;
+    struct aws_h1_decoded_header header;
     header.name = aws_http_str_to_header_name(name);
     header.name_data = name;
     header.value_data = value;

--- a/tests/test_h1_decoder.c
+++ b/tests/test_h1_decoder.c
@@ -38,7 +38,7 @@ static const bool s_response = false;
 
 static struct aws_logger s_logger;
 
-static int s_on_header_stub(const struct aws_http_decoded_header *header, void *user_data) {
+static int s_on_header_stub(const struct aws_h1_decoded_header *header, void *user_data) {
     (void)header;
     (void)user_data;
     return AWS_OP_SUCCESS;
@@ -275,7 +275,7 @@ struct s_header_params {
     const char **header_names;
 };
 
-static int s_got_header(const struct aws_http_decoded_header *header, void *user_data) {
+static int s_got_header(const struct aws_h1_decoded_header *header, void *user_data) {
     struct s_header_params *params = (struct s_header_params *)user_data;
     if (params->index < params->max_index) {
         if (params->first_error == AWS_OP_SUCCESS) {


### PR DESCRIPTION
We had moved this to a common area when we thought the to-be-built h2 decoder would use the same callbacks. It totally does not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
