### PR TITLE
Add compression options to aws_http_header struct

### DIFF
--- a/include/aws/http/private/h2_decoder.h
+++ b/include/aws/http/private/h2_decoder.h
@@ -36,21 +36,13 @@ struct aws_h2_decoder_vtable {
     /* For HEADERS header-block: _begin() is called, then 0+ _i() calls, then _end().
      * No other decoder callbacks will occur in this time. */
     int (*on_headers_begin)(uint32_t stream_id, void *userdata);
-    int (*on_headers_i)(
-        uint32_t stream_id,
-        const struct aws_http_header *header,
-        enum aws_h2_header_field_hpack_behavior hpack_behavior,
-        void *userdata);
+    int (*on_headers_i)(uint32_t stream_id, const struct aws_http_header *header, void *userdata);
     int (*on_headers_end)(uint32_t stream_id, void *userdata);
 
     /* For PUSH_PROMISE header-block: _begin() is called, then 0+ _i() calls, then _end().
      * No other decoder callbacks will occur in this time. */
     int (*on_push_promise_begin)(uint32_t stream_id, uint32_t promised_stream_id, void *userdata);
-    int (*on_push_promise_i)(
-        uint32_t stream_id,
-        const struct aws_http_header *header,
-        enum aws_h2_header_field_hpack_behavior hpack_behavior,
-        void *userdata);
+    int (*on_push_promise_i)(uint32_t stream_id, const struct aws_http_header *header, void *userdata);
 
     int (*on_push_promise_end)(uint32_t stream_id, void *userdata);
 

--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -78,13 +78,6 @@ enum aws_h2_settings {
  * See RFC-7540 3.5 - HTTP/2 Connection Preface */
 extern const struct aws_byte_cursor aws_h2_connection_preface_client_string;
 
-/* RFC-7541 2.4 */
-enum aws_h2_header_field_hpack_behavior {
-    AWS_H2_HEADER_BEHAVIOR_SAVE,
-    AWS_H2_HEADER_BEHAVIOR_NO_SAVE,
-    AWS_H2_HEADER_BEHAVIOR_NO_FORWARD_SAVE,
-};
-
 /**
  * Present in all frames that may have set AWS_H2_FRAME_F_PRIORITY
  *
@@ -101,13 +94,8 @@ struct aws_h2_frame_priority_settings {
     uint8_t weight;
 };
 
-struct aws_h2_frame_header_field {
-    struct aws_http_header header;
-    enum aws_h2_header_field_hpack_behavior hpack_behavior;
-    const size_t index; /* DO NOT TOUCH unless you're pretty sure you know what you're doing */
-};
 struct aws_h2_frame_header_block {
-    /* array_list of aws_h2_frame_header_field */
+    /* array_list of aws_http_header */
     struct aws_array_list header_fields;
 };
 

--- a/include/aws/http/private/hpack.h
+++ b/include/aws/http/private/hpack.h
@@ -36,15 +36,10 @@ struct aws_hpack_decode_result {
 
     union {
         /* If type is AWS_HPACK_DECODE_T_HEADER_FIELD */
-        struct aws_hpack_decoded_header_field {
-            struct aws_http_header header;
-            enum aws_h2_header_field_hpack_behavior hpack_behavior;
-        } header_field;
+        struct aws_http_header header_field;
 
         /* If type is AWS_HPACK_DECODE_T_DYNAMIC_TABLE_RESIZE */
-        struct aws_hpack_decoded_resize {
-            size_t size;
-        } dynamic_table_resize;
+        size_t dynamic_table_resize;
     } data;
 };
 

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -30,12 +30,47 @@ struct aws_input_stream;
 struct aws_http_stream;
 
 /**
+ * Controls whether a header's strings may be compressed by encoding the index of
+ * strings in a cache, rather than encoding the literal string.
+ *
+ * This setting has no effect on HTTP/1.x connections.
+ * On HTTP/2 connections this controls HPACK behavior.
+ * See RFC-7541 Section 7.1 for security considerations.
+ */
+enum aws_http_header_compression {
+    /**
+     * Compress header by encoding the cached index of its strings,
+     * or by updating the cache to contain these strings for future reference.
+     * Best for headers that are sent repeatedly.
+     * This is the default setting.
+     */
+    AWS_HTTP_HEADER_COMPRESSION_USE_CACHE,
+
+    /**
+     * Encode header strings literally.
+     * If an intermediary re-broadcasts the headers, it is permitted to use cache.
+     * Best for unique headers that are unlikely to repeat.
+     */
+    AWS_HTTP_HEADER_COMPRESSION_NO_CACHE,
+
+    /**
+     * Encode header strings literally and forbid all intermediaries from using
+     * cache when re-broadcasting.
+     * Best for header fields that are highly valuable or sensitive to recovery.
+     */
+    AWS_HTTP_HEADER_COMPRESSION_NO_FORWARD_CACHE,
+};
+
+/**
  * A lightweight HTTP header struct.
  * Note that the underlying strings are not owned by the byte cursors.
  */
 struct aws_http_header {
     struct aws_byte_cursor name;
     struct aws_byte_cursor value;
+
+    /* Controls whether the header's strings may be compressed via caching. */
+    enum aws_http_header_compression compression;
 };
 
 /**

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -1035,19 +1035,19 @@ static int s_state_fn_header_block_entry(struct aws_h2_decoder *decoder, struct 
     /* #TODO Cookie headers must be concatenated into single delivery RFC-7540 8.1.2.5 */
 
     if (result.type == AWS_HPACK_DECODE_T_HEADER_FIELD) {
-        const struct aws_hpack_decoded_header_field *field = &result.data.header_field;
+        const struct aws_http_header *header_field = &result.data.header_field;
 
         DECODER_LOGF(
             TRACE,
             decoder,
             "Decoded header field: \"" PRInSTR ": " PRInSTR "\"",
-            AWS_BYTE_CURSOR_PRI(field->header.name),
-            AWS_BYTE_CURSOR_PRI(field->header.value));
+            AWS_BYTE_CURSOR_PRI(header_field->name),
+            AWS_BYTE_CURSOR_PRI(header_field->value));
 
         if (decoder->header_block_in_progress.is_push_promise) {
-            DECODER_CALL_VTABLE_STREAM_ARGS(decoder, on_push_promise_i, &field->header, field->hpack_behavior);
+            DECODER_CALL_VTABLE_STREAM_ARGS(decoder, on_push_promise_i, header_field);
         } else {
-            DECODER_CALL_VTABLE_STREAM_ARGS(decoder, on_headers_i, &field->header, field->hpack_behavior);
+            DECODER_CALL_VTABLE_STREAM_ARGS(decoder, on_headers_i, header_field);
         }
     }
 

--- a/source/h2_stream.c
+++ b/source/h2_stream.c
@@ -128,12 +128,9 @@ static struct aws_h2_frame_headers *s_new_headers_frame(
     /* #TODO headers frame needs to respect max frame size, and use CONTINUATION */
     const size_t num_headers = aws_http_message_get_header_count(message);
     for (size_t i = 0; i < num_headers; ++i) {
-        struct aws_h2_frame_header_field header_field = {
-            /* #TODO: let user specify hpack behavior */
-            .hpack_behavior = AWS_H2_HEADER_BEHAVIOR_SAVE,
-        };
+        struct aws_http_header header_field;
 
-        aws_http_message_get_header(message, &header_field.header, i);
+        aws_http_message_get_header(message, &header_field, i);
         if (aws_array_list_push_back(&headers_frame->header_block.header_fields, &header_field)) {
             goto error_push_back;
         }

--- a/source/request_response.c
+++ b/source/request_response.c
@@ -110,7 +110,7 @@ int aws_http_headers_add(struct aws_http_headers *headers, struct aws_byte_curso
         return AWS_OP_ERR;
     }
 
-    struct aws_http_header header = {name, value};
+    struct aws_http_header header = {.name = name, .value = value};
 
     /* Store our own copy of the strings.
      * We put the name and value into the same allocation. */

--- a/tests/fuzz/fuzz_h2_decoder_correct.c
+++ b/tests/fuzz/fuzz_h2_decoder_correct.c
@@ -30,20 +30,20 @@ static void s_generate_header_block(struct aws_byte_cursor *input, struct aws_h2
 
     /* Requires 4 bytes: type, size, and then 1 each for name & value */
     while (input->len >= 4) {
-        struct aws_h2_frame_header_field header;
+        struct aws_http_header header;
         AWS_ZERO_STRUCT(header);
 
         uint8_t type = 0;
         aws_byte_cursor_read_u8(input, &type);
         switch (type % 3) {
             case 0:
-                header.hpack_behavior = AWS_H2_HEADER_BEHAVIOR_SAVE;
+                header.compression = AWS_HTTP_HEADER_COMPRESSION_USE_CACHE;
                 break;
             case 1:
-                header.hpack_behavior = AWS_H2_HEADER_BEHAVIOR_NO_SAVE;
+                header.compression = AWS_HTTP_HEADER_COMPRESSION_NO_CACHE;
                 break;
             case 2:
-                header.hpack_behavior = AWS_H2_HEADER_BEHAVIOR_NO_FORWARD_SAVE;
+                header.compression = AWS_HTTP_HEADER_COMPRESSION_NO_FORWARD_CACHE;
                 break;
         }
 
@@ -70,8 +70,8 @@ static void s_generate_header_block(struct aws_byte_cursor *input, struct aws_h2
             name_len = input->len / 2;
             value_len = input->len - name_len;
         }
-        header.header.name = aws_byte_cursor_advance(input, name_len);
-        header.header.value = aws_byte_cursor_advance(input, value_len);
+        header.name = aws_byte_cursor_advance(input, name_len);
+        header.value = aws_byte_cursor_advance(input, value_len);
 
         aws_array_list_push_back(&header_block->header_fields, &header);
     }


### PR DESCRIPTION
Previously, the HPACK compression options were only exposed in private h2 headers.
Now the public `aws_http_header` struct has the option exposed.

Check out the `aws_http_header_compression` enum and tell me what you think of the name and comments. Didn't use the term "hpack" because we'll be using this for HTTP/3 as well, where it's called QPACK (and has even more options, but they're thematically similar).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
