### PR TITLE
Allow s2n to auto-detect Post Quantum Assembly support

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -18,6 +18,5 @@
         ["{python}", "{project_dir}/integration-testing/http_client_test.py", "{install_dir}/bin/elasticurl{exe}"]
     ],
     "cmake_args": [
-        "-DS2N_NO_PQ_ASM=ON"
     ]
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
s2n's CMake build can now [auto-detect if Post Quantum Assembly is supported](https://github.com/awslabs/s2n/blob/master/CMakeLists.txt#L116) by the Platform/Compiler combination. There's no longer a need to force it to be turned off. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
