### PR TITLE
H2 test helper

### DIFF
--- a/include/aws/http/private/h1_decoder.h
+++ b/include/aws/http/private/h1_decoder.h
@@ -81,7 +81,7 @@ AWS_HTTP_API struct aws_h1_decoder *aws_h1_decoder_new(struct aws_h1_decoder_par
 AWS_HTTP_API void aws_h1_decoder_destroy(struct aws_h1_decoder *decoder);
 AWS_HTTP_API int aws_h1_decode(struct aws_h1_decoder *decoder, struct aws_byte_cursor *data);
 
-AWS_HTTP_API void aws_h1_decoder_set_logging_id(struct aws_h1_decoder *decoder, void *id);
+AWS_HTTP_API void aws_h1_decoder_set_logging_id(struct aws_h1_decoder *decoder, const void *id);
 AWS_HTTP_API void aws_h1_decoder_set_body_headers_ignored(struct aws_h1_decoder *decoder, bool body_headers_ignored);
 
 /* RFC-7230 section 4.2 Message Format */

--- a/include/aws/http/private/h1_encoder.h
+++ b/include/aws/http/private/h1_encoder.h
@@ -43,7 +43,7 @@ struct aws_h1_encoder {
     enum aws_h1_encoder_state state;
     struct aws_h1_encoder_message *message;
     uint64_t progress_bytes;
-    void *logging_id;
+    const void *logging_id;
 };
 
 AWS_EXTERN_C_BEGIN

--- a/include/aws/http/private/h2_decoder.h
+++ b/include/aws/http/private/h2_decoder.h
@@ -89,7 +89,7 @@ struct aws_h2_decoder_params {
     struct aws_allocator *alloc;
     const struct aws_h2_decoder_vtable *vtable;
     void *userdata;
-    void *logging_id;
+    const void *logging_id;
     bool is_server;
 
     /* If true, do not expect the connection preface and immediately accept any frame type.

--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -159,7 +159,10 @@ int aws_h2_validate_stream_id(uint32_t stream_id);
  * 2. Encode the frame using aws_h2_encode_frame()
  */
 AWS_HTTP_API
-int aws_h2_frame_encoder_init(struct aws_h2_frame_encoder *encoder, struct aws_allocator *allocator, void *logging_id);
+int aws_h2_frame_encoder_init(
+    struct aws_h2_frame_encoder *encoder,
+    struct aws_allocator *allocator,
+    const void *logging_id);
 
 AWS_HTTP_API
 void aws_h2_frame_encoder_clean_up(struct aws_h2_frame_encoder *encoder);

--- a/include/aws/http/private/hpack.h
+++ b/include/aws/http/private/hpack.h
@@ -71,7 +71,7 @@ AWS_HTTP_API
 struct aws_hpack_context *aws_hpack_context_new(
     struct aws_allocator *allocator,
     enum aws_http_log_subject log_subject,
-    void *log_id);
+    const void *log_id);
 
 AWS_HTTP_API
 void aws_hpack_context_destroy(struct aws_hpack_context *context);

--- a/source/h1_decoder.c
+++ b/source/h1_decoder.c
@@ -50,7 +50,7 @@ struct aws_h1_decoder {
     bool body_headers_ignored;
     bool body_headers_forbidden;
     enum aws_http_header_block header_block;
-    void *logging_id;
+    const void *logging_id;
 
     /* User callbacks and settings. */
     struct aws_h1_decoder_vtable vtable;
@@ -766,7 +766,7 @@ enum aws_http_header_block aws_h1_decoder_get_header_block(const struct aws_h1_d
     return decoder->header_block;
 }
 
-void aws_h1_decoder_set_logging_id(struct aws_h1_decoder *decoder, void *id) {
+void aws_h1_decoder_set_logging_id(struct aws_h1_decoder *decoder, const void *id) {
     decoder->logging_id = id;
 }
 

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -125,7 +125,7 @@ static const struct decoder_state *s_state_frames[] = {
 struct aws_h2_decoder {
     /* Implementation data. */
     struct aws_allocator *alloc;
-    void *logging_id;
+    const void *logging_id;
     struct aws_hpack_context *hpack;
     bool is_server;
     struct aws_byte_buf scratch;

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -231,7 +231,10 @@ static void s_frame_prefix_encode(
 /***********************************************************************************************************************
  * Encoder
  **********************************************************************************************************************/
-int aws_h2_frame_encoder_init(struct aws_h2_frame_encoder *encoder, struct aws_allocator *allocator, void *logging_id) {
+int aws_h2_frame_encoder_init(
+    struct aws_h2_frame_encoder *encoder,
+    struct aws_allocator *allocator,
+    const void *logging_id) {
 
     AWS_PRECONDITION(encoder);
     AWS_PRECONDITION(allocator);

--- a/source/hpack.c
+++ b/source/hpack.c
@@ -230,7 +230,7 @@ struct aws_hpack_context {
 
     enum aws_hpack_huffman_mode huffman_mode;
     enum aws_http_log_subject log_subject;
-    void *log_id;
+    const void *log_id;
 
     struct aws_huffman_encoder encoder;
     struct aws_huffman_decoder decoder;
@@ -316,7 +316,7 @@ struct aws_hpack_context {
 struct aws_hpack_context *aws_hpack_context_new(
     struct aws_allocator *allocator,
     enum aws_http_log_subject log_subject,
-    void *log_id) {
+    const void *log_id) {
 
     struct aws_hpack_context *context = aws_mem_calloc(allocator, 1, sizeof(struct aws_hpack_context));
     if (!context) {

--- a/tests/h2_test_helper.c
+++ b/tests/h2_test_helper.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "h2_test_helper.h"
+
+#include <aws/http/private/h2_decoder.h>
+
+static const void *s_logging_id = (void *)0xAAAAAAAA;
+
+/*******************************************************************************
+ * h2_decoded_frame
+ ******************************************************************************/
+static int s_frame_init(
+    struct h2_decoded_frame *frame,
+    struct aws_allocator *alloc,
+    enum aws_h2_frame_type type,
+    uint32_t stream_id) {
+
+    AWS_ZERO_STRUCT(*frame);
+    frame->type = type;
+    frame->stream_id = stream_id;
+    frame->headers = aws_http_headers_new(alloc);
+    ASSERT_SUCCESS(aws_array_list_init_dynamic(&frame->settings, alloc, 16, sizeof(struct aws_h2_frame_setting)));
+    ASSERT_SUCCESS(aws_byte_buf_init(&frame->data, alloc, 1024));
+    return AWS_OP_SUCCESS;
+}
+
+static void s_frame_clean_up(struct h2_decoded_frame *frame) {
+    aws_http_headers_release(frame->headers);
+    aws_array_list_clean_up(&frame->settings);
+    aws_byte_buf_clean_up(&frame->data);
+}
+
+int h2_decoded_frame_check_finished(
+    const struct h2_decoded_frame *frame,
+    enum aws_h2_frame_type expected_type,
+    uint32_t expected_stream_id) {
+
+    ASSERT_INT_EQUALS(expected_type, frame->type);
+    ASSERT_UINT_EQUALS(expected_stream_id, frame->stream_id);
+    ASSERT_TRUE(frame->finished);
+    return AWS_OP_SUCCESS;
+}
+
+/*******************************************************************************
+ * h2_decode_tester
+ ******************************************************************************/
+
+size_t h2_decode_tester_frame_count(const struct h2_decode_tester *decode_tester) {
+    return aws_array_list_length(&decode_tester->frames);
+}
+
+struct h2_decoded_frame *h2_decode_tester_get_frame(const struct h2_decode_tester *decode_tester, size_t i) {
+    AWS_FATAL_ASSERT(h2_decode_tester_frame_count(decode_tester) > i);
+    struct h2_decoded_frame *frame = NULL;
+    aws_array_list_get_at_ptr(&decode_tester->frames, (void **)&frame, i);
+    return frame;
+}
+
+struct h2_decoded_frame *h2_decode_tester_latest_frame(const struct h2_decode_tester *decode_tester) {
+    size_t frame_count = h2_decode_tester_frame_count(decode_tester);
+    AWS_FATAL_ASSERT(frame_count != 0);
+    return h2_decode_tester_get_frame(decode_tester, frame_count - 1);
+}
+
+int h2_decode_tester_check_data_across_frames(
+    const struct h2_decode_tester *decode_tester,
+    uint32_t stream_id,
+    struct aws_byte_cursor expected,
+    bool expect_end_stream) {
+
+    struct aws_byte_buf data;
+    ASSERT_SUCCESS(aws_byte_buf_init(&data, decode_tester->alloc, 128));
+
+    bool found_end_stream = false;
+
+    for (size_t frame_i = 0; frame_i < h2_decode_tester_frame_count(decode_tester); ++frame_i) {
+        struct h2_decoded_frame *frame = h2_decode_tester_get_frame(decode_tester, frame_i);
+
+        if (frame->type == AWS_H2_FRAME_T_DATA && frame->stream_id == stream_id) {
+            struct aws_byte_cursor frame_data = aws_byte_cursor_from_buf(&frame->data);
+            ASSERT_SUCCESS(aws_byte_buf_append_dynamic(&data, &frame_data));
+
+            found_end_stream = frame->end_stream;
+        }
+    }
+
+    ASSERT_BIN_ARRAYS_EQUALS(expected.ptr, expected.len, data.buffer, data.len);
+    ASSERT_UINT_EQUALS(expect_end_stream, found_end_stream);
+
+    aws_byte_buf_clean_up(&data);
+    return AWS_OP_SUCCESS;
+}
+
+int h2_decode_tester_check_data_str_across_frames(
+    const struct h2_decode_tester *decode_tester,
+    uint32_t stream_id,
+    const char *expected,
+    bool expect_end_stream) {
+
+    return h2_decode_tester_check_data_across_frames(
+        decode_tester, stream_id, aws_byte_cursor_from_c_str(expected), expect_end_stream);
+}
+
+/* decode-tester begins recording a new frame's data */
+static int s_begin_new_frame(
+    struct h2_decode_tester *decode_tester,
+    enum aws_h2_frame_type type,
+    uint32_t stream_id,
+    struct h2_decoded_frame **out_frame) {
+
+    /* If there's a previous frame, assert that we know it was finished.
+     * If this fails, some on_X_begin(), on_X_i(), on_X_end() loop didn't fire correctly.
+     * It should be impossible for an unrelated callback to fire during these loops */
+    if (aws_array_list_length(&decode_tester->frames) > 0) {
+        const struct h2_decoded_frame *prev_frame = h2_decode_tester_latest_frame(decode_tester);
+        ASSERT_TRUE(prev_frame->finished);
+    }
+
+    /* Create new frame */
+    struct h2_decoded_frame new_frame;
+    ASSERT_SUCCESS(s_frame_init(&new_frame, decode_tester->alloc, type, stream_id));
+    ASSERT_SUCCESS(aws_array_list_push_back(&decode_tester->frames, &new_frame));
+
+    if (out_frame) {
+        aws_array_list_get_at_ptr(
+            &decode_tester->frames, (void **)out_frame, aws_array_list_length(&decode_tester->frames) - 1);
+    }
+    return AWS_OP_SUCCESS;
+}
+
+/* decode-tester stops recording the latest frame's data */
+static int s_end_current_frame(
+    struct h2_decode_tester *decode_tester,
+    enum aws_h2_frame_type type,
+    uint32_t stream_id) {
+    struct h2_decoded_frame *frame = h2_decode_tester_latest_frame(decode_tester);
+    ASSERT_FALSE(frame->finished);
+    frame->finished = true;
+    ASSERT_SUCCESS(h2_decoded_frame_check_finished(frame, type, stream_id));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_headers_begin(uint32_t stream_id, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_HEADERS, stream_id, NULL /*out_frame*/));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_on_header(bool is_push_promise, uint32_t stream_id, const struct aws_http_header *header, void *userdata) {
+
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame = h2_decode_tester_latest_frame(decode_tester);
+
+    /* Validate */
+    if (is_push_promise) {
+        ASSERT_INT_EQUALS(AWS_H2_FRAME_T_PUSH_PROMISE, frame->type);
+    } else {
+        ASSERT_INT_EQUALS(AWS_H2_FRAME_T_HEADERS, frame->type);
+    }
+
+    ASSERT_FALSE(frame->finished);
+    ASSERT_UINT_EQUALS(frame->stream_id, stream_id);
+
+    /* Stash header */
+    ASSERT_SUCCESS(aws_http_headers_add_header(frame->headers, header));
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_headers_i(uint32_t stream_id, const struct aws_http_header *header, void *userdata) {
+    return s_on_header(false /* is_push_promise */, stream_id, header, userdata);
+}
+
+static int s_decoder_on_headers_end(uint32_t stream_id, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_HEADERS, stream_id));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_push_promise_begin(uint32_t stream_id, uint32_t promised_stream_id, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_PUSH_PROMISE, stream_id, &frame /*out_frame*/));
+
+    frame->promised_stream_id = promised_stream_id;
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_push_promise_i(uint32_t stream_id, const struct aws_http_header *header, void *userdata) {
+    return s_on_header(true /* is_push_promise */, stream_id, header, userdata);
+}
+
+static int s_decoder_on_push_promise_end(uint32_t stream_id, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_PUSH_PROMISE, stream_id));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_data(uint32_t stream_id, struct aws_byte_cursor data, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+
+    /* Pretend each on_data callback is a full DATA frame for the purposes of these tests */
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_DATA, stream_id, &frame));
+
+    /* Stash data*/
+    ASSERT_SUCCESS(aws_byte_buf_append_dynamic(&frame->data, &data));
+
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_DATA, stream_id));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_end_stream(uint32_t stream_id, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame = h2_decode_tester_latest_frame(decode_tester);
+
+    /* Validate */
+
+    /* on_end_stream should fire IMMEDIATELY after on_data OR after on_headers_end.
+     * This timing lets the user close the stream from this callback without waiting for any trailing data/headers
+     */
+    ASSERT_TRUE(frame->finished);
+    ASSERT_TRUE(frame->type == AWS_H2_FRAME_T_HEADERS || frame->type == AWS_H2_FRAME_T_DATA);
+    ASSERT_UINT_EQUALS(frame->stream_id, stream_id);
+
+    ASSERT_FALSE(frame->end_stream);
+
+    /* Stash */
+    frame->end_stream = true;
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_rst_stream(uint32_t stream_id, uint32_t error_code, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_RST_STREAM, stream_id, &frame));
+
+    /* Stash data*/
+    frame->error_code = error_code;
+
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_RST_STREAM, stream_id));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_settings_begin(void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_SETTINGS, 0, &frame));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_settings_i(uint16_t setting_id, uint32_t value, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame = h2_decode_tester_latest_frame(decode_tester);
+
+    /* Validate */
+    ASSERT_INT_EQUALS(AWS_H2_FRAME_T_SETTINGS, frame->type);
+    ASSERT_FALSE(frame->finished);
+
+    /* Stash setting */
+    struct aws_h2_frame_setting setting = {setting_id, value};
+    ASSERT_SUCCESS(aws_array_list_push_back(&frame->settings, &setting));
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_settings_end(void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_SETTINGS, 0));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_settings_ack(void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_SETTINGS, 0 /*stream_id*/, &frame));
+
+    /* Stash data*/
+    frame->ack = true;
+
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_SETTINGS, 0 /*stream_id*/));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_ping(uint8_t opaque_data[AWS_H2_PING_DATA_SIZE], void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_PING, 0 /*stream_id*/, &frame));
+
+    /* Stash data*/
+    memcpy(frame->ping_opaque_data, opaque_data, AWS_H2_PING_DATA_SIZE);
+
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_PING, 0 /*stream_id*/));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_ping_ack(uint8_t opaque_data[AWS_H2_PING_DATA_SIZE], void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_PING, 0 /*stream_id*/, &frame));
+
+    /* Stash data*/
+    memcpy(frame->ping_opaque_data, opaque_data, AWS_H2_PING_DATA_SIZE);
+    frame->ack = true;
+
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_PING, 0 /*stream_id*/));
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_goaway_begin(
+    uint32_t last_stream,
+    uint32_t error_code,
+    uint32_t debug_data_length,
+    void *userdata) {
+
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_GOAWAY, 0, &frame));
+
+    frame->goaway_last_stream_id = last_stream;
+    frame->error_code = error_code;
+    frame->goaway_debug_data_remaining = debug_data_length;
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_goaway_i(struct aws_byte_cursor debug_data, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame = h2_decode_tester_latest_frame(decode_tester);
+
+    /* Validate */
+    ASSERT_INT_EQUALS(AWS_H2_FRAME_T_GOAWAY, frame->type);
+    ASSERT_FALSE(frame->finished);
+    ASSERT_TRUE(frame->goaway_debug_data_remaining >= debug_data.len);
+
+    frame->goaway_debug_data_remaining -= (uint32_t)debug_data.len;
+
+    /* Stash data */
+    ASSERT_SUCCESS(aws_byte_buf_append_dynamic(&frame->data, &debug_data));
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_goaway_end(void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_GOAWAY, 0));
+
+    struct h2_decoded_frame *frame = h2_decode_tester_latest_frame(decode_tester);
+    ASSERT_UINT_EQUALS(0, frame->goaway_debug_data_remaining);
+
+    return AWS_OP_SUCCESS;
+}
+
+static int s_decoder_on_window_update(uint32_t stream_id, uint32_t window_size_increment, void *userdata) {
+    struct h2_decode_tester *decode_tester = userdata;
+    struct h2_decoded_frame *frame;
+    ASSERT_SUCCESS(s_begin_new_frame(decode_tester, AWS_H2_FRAME_T_WINDOW_UPDATE, stream_id, &frame));
+
+    frame->window_size_increment = window_size_increment;
+
+    ASSERT_SUCCESS(s_end_current_frame(decode_tester, AWS_H2_FRAME_T_WINDOW_UPDATE, stream_id));
+
+    return AWS_OP_SUCCESS;
+}
+
+static struct aws_h2_decoder_vtable s_decoder_vtable = {
+    .on_headers_begin = s_decoder_on_headers_begin,
+    .on_headers_i = s_decoder_on_headers_i,
+    .on_headers_end = s_decoder_on_headers_end,
+    .on_push_promise_begin = s_decoder_on_push_promise_begin,
+    .on_push_promise_i = s_decoder_on_push_promise_i,
+    .on_push_promise_end = s_decoder_on_push_promise_end,
+    .on_data = s_decoder_on_data,
+    .on_end_stream = s_decoder_on_end_stream,
+    .on_rst_stream = s_decoder_on_rst_stream,
+    .on_settings_begin = s_decoder_on_settings_begin,
+    .on_settings_i = s_decoder_on_settings_i,
+    .on_settings_end = s_decoder_on_settings_end,
+    .on_settings_ack = s_decoder_on_settings_ack,
+    .on_ping = s_decoder_on_ping,
+    .on_ping_ack = s_decoder_on_ping_ack,
+    .on_goaway_begin = s_decoder_on_goaway_begin,
+    .on_goaway_i = s_decoder_on_goaway_i,
+    .on_goaway_end = s_decoder_on_goaway_end,
+    .on_window_update = s_decoder_on_window_update,
+};
+
+int h2_decode_tester_init(struct h2_decode_tester *decode_tester, const struct h2_decode_tester_options *options) {
+    AWS_ZERO_STRUCT(*decode_tester);
+    decode_tester->alloc = options->alloc;
+
+    struct aws_h2_decoder_params decoder_params = {
+        .alloc = options->alloc,
+        .vtable = &s_decoder_vtable,
+        .userdata = decode_tester,
+        .logging_id = s_logging_id,
+        .is_server = options->is_server,
+        .skip_connection_preface = options->skip_connection_preface,
+    };
+    decode_tester->decoder = aws_h2_decoder_new(&decoder_params);
+    ASSERT_NOT_NULL(decode_tester->decoder);
+
+    ASSERT_SUCCESS(
+        aws_array_list_init_dynamic(&decode_tester->frames, options->alloc, 16, sizeof(struct h2_decoded_frame)));
+    return AWS_OP_SUCCESS;
+}
+
+void h2_decode_tester_clean_up(struct h2_decode_tester *decode_tester) {
+    aws_h2_decoder_destroy(decode_tester->decoder);
+
+    for (size_t i = 0; i < aws_array_list_length(&decode_tester->frames); ++i) {
+        struct h2_decoded_frame *frame;
+        aws_array_list_get_at_ptr(&decode_tester->frames, (void **)&frame, i);
+        s_frame_clean_up(frame);
+    }
+    aws_array_list_clean_up(&decode_tester->frames);
+
+    AWS_ZERO_STRUCT(*decode_tester);
+}
+
+/*******************************************************************************
+ * h2_fake_peer
+ ******************************************************************************/
+
+int h2_fake_peer_init(struct h2_fake_peer *peer, const struct h2_fake_peer_options *options) {
+    AWS_ZERO_STRUCT(*peer);
+    peer->alloc = options->alloc;
+    peer->testing_channel = options->testing_channel;
+
+    ASSERT_SUCCESS(aws_h2_frame_encoder_init(&peer->encoder, peer->alloc, s_logging_id));
+
+    struct h2_decode_tester_options decode_options = {.alloc = options->alloc, .is_server = options->is_server};
+    ASSERT_SUCCESS(h2_decode_tester_init(&peer->decode, &decode_options));
+    return AWS_OP_SUCCESS;
+}
+
+void h2_fake_peer_clean_up(struct h2_fake_peer *peer) {
+    aws_h2_frame_encoder_clean_up(&peer->encoder);
+    h2_decode_tester_clean_up(&peer->decode);
+    AWS_ZERO_STRUCT(peer);
+}

--- a/tests/h2_test_helper.c
+++ b/tests/h2_test_helper.c
@@ -18,8 +18,6 @@
 #include <aws/http/private/h2_decoder.h>
 #include <aws/testing/io_testing_channel.h>
 
-static const void *s_logging_id = (void *)0xAAAAAAAA;
-
 /*******************************************************************************
  * h2_decoded_frame
  ******************************************************************************/
@@ -413,7 +411,6 @@ int h2_decode_tester_init(struct h2_decode_tester *decode_tester, const struct h
         .alloc = options->alloc,
         .vtable = &s_decoder_vtable,
         .userdata = decode_tester,
-        .logging_id = s_logging_id,
         .is_server = options->is_server,
         .skip_connection_preface = options->skip_connection_preface,
     };
@@ -448,7 +445,7 @@ int h2_fake_peer_init(struct h2_fake_peer *peer, const struct h2_fake_peer_optio
     peer->testing_channel = options->testing_channel;
     peer->is_server = options->is_server;
 
-    ASSERT_SUCCESS(aws_h2_frame_encoder_init(&peer->encoder, peer->alloc, s_logging_id));
+    ASSERT_SUCCESS(aws_h2_frame_encoder_init(&peer->encoder, peer->alloc, NULL /*logging_id*/));
 
     struct h2_decode_tester_options decode_options = {.alloc = options->alloc, .is_server = options->is_server};
     ASSERT_SUCCESS(h2_decode_tester_init(&peer->decode, &decode_options));

--- a/tests/h2_test_helper.h
+++ b/tests/h2_test_helper.h
@@ -67,6 +67,8 @@ int h2_decoded_frame_check_finished(
     enum aws_h2_frame_type expected_type,
     uint32_t expected_stream_id);
 
+/******************************************************************************/
+
 /**
  * Translates decoder callbacks into an array-list of h2_decoded_frames.
  */
@@ -107,6 +109,8 @@ int h2_decode_tester_check_data_str_across_frames(
     const char *expected,
     bool expect_end_stream);
 
+/******************************************************************************/
+
 /**
  * Fake HTTP/2 peer.
  * Can decode H2 frames that are are written to the testing channel.
@@ -118,6 +122,7 @@ struct h2_fake_peer {
 
     struct aws_h2_frame_encoder encoder;
     struct h2_decode_tester decode;
+    bool is_server;
 };
 
 struct h2_fake_peer_options {
@@ -129,12 +134,26 @@ struct h2_fake_peer_options {
 int h2_fake_peer_init(struct h2_fake_peer *peer, const struct h2_fake_peer_options *options);
 void h2_fake_peer_clean_up(struct h2_fake_peer *peer);
 
-/* Pop all written messages off the testing-channel and run them through the peer's decode-tester */
+/**
+ * Pop all written messages off the testing-channel and run them through the peer's decode-tester
+ */
 int h2_fake_peer_decode_messages_from_testing_channel(struct h2_fake_peer *peer);
 
+/**
+ * Encode frame and push it into the testing-channel in the read-direction.
+ * Takes ownership of frame and destroys after sending.
+ */
 int h2_fake_peer_send_frame(struct h2_fake_peer *peer, struct aws_h2_frame *frame);
 
-/* Peer sends the connection preface with default settings */
+/**
+ * Peer sends the connection preface with specified settings.
+ * Takes ownership of frame and destroys after sending
+ */
+int h2_fake_peer_send_connection_preface(struct h2_fake_peer *peer, struct aws_h2_frame *settings);
+
+/**
+ * Peer sends the connection preface with default settings.
+ */
 int h2_fake_peer_send_connection_preface_default_settings(struct h2_fake_peer *peer);
 
 #endif /* AWS_HTTP_H2_TEST_HELPER_H */

--- a/tests/h2_test_helper.h
+++ b/tests/h2_test_helper.h
@@ -129,4 +129,12 @@ struct h2_fake_peer_options {
 int h2_fake_peer_init(struct h2_fake_peer *peer, const struct h2_fake_peer_options *options);
 void h2_fake_peer_clean_up(struct h2_fake_peer *peer);
 
+/* Pop all written messages off the testing-channel and run them through the peer's decode-tester */
+int h2_fake_peer_decode_messages_from_testing_channel(struct h2_fake_peer *peer);
+
+int h2_fake_peer_send_frame(struct h2_fake_peer *peer, struct aws_h2_frame *frame);
+
+/* Peer sends the connection preface with default settings */
+int h2_fake_peer_send_connection_preface_default_settings(struct h2_fake_peer *peer);
+
 #endif /* AWS_HTTP_H2_TEST_HELPER_H */

--- a/tests/h2_test_helper.h
+++ b/tests/h2_test_helper.h
@@ -1,0 +1,132 @@
+#ifndef AWS_HTTP_H2_TEST_HELPER_H
+#define AWS_HTTP_H2_TEST_HELPER_H
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include <aws/common/array_list.h>
+#include <aws/http/private/h2_frames.h>
+#include <aws/http/request_response.h>
+#include <aws/testing/aws_test_harness.h>
+
+/**
+ * Information gathered about a given frame from decoder callbacks.
+ * These aren't 1:1 with literal H2 frames:
+ * - The decoder hides the existence of CONTINUATION frames,
+ *   their data continues the preceding HEADERS or PUSH_PROMISE frame.
+ *
+ * - A DATA frame could appear as N on_data callbacks.
+ *
+ * - The on_end_stream callback fires after all other callbacks for that frame,
+ *   so we count it as part of the preceding "finished" frame.
+ */
+struct h2_decoded_frame {
+    /* If true, we expect no further callbacks regarding this frame */
+    bool finished;
+
+    enum aws_h2_frame_type type; /* All frame types have this */
+    uint32_t stream_id;          /* All frame types have this */
+
+    /*
+     * Everything else is only found in certain frame types
+     */
+
+    bool end_stream; /* HEADERS and DATA might have this */
+    bool ack;        /* PING and SETTINGS might have this */
+
+    uint32_t error_code;                             /* RST_STREAM and GOAWAY have this */
+    uint32_t promised_stream_id;                     /* PUSH_PROMISE has this */
+    uint32_t goaway_last_stream_id;                  /* GOAWAY has this */
+    uint32_t goaway_debug_data_remaining;            /* GOAWAY has this*/
+    uint8_t ping_opaque_data[AWS_H2_PING_DATA_SIZE]; /* PING has this */
+    uint32_t window_size_increment;                  /* WINDOW_UPDATE has this */
+
+    struct aws_http_headers *headers; /* HEADERS and PUSH_PROMISE have this */
+    struct aws_array_list settings;   /* contains aws_h2_frame_setting, SETTINGS has this */
+    struct aws_byte_buf data /* DATA has this */;
+};
+
+/**
+ * Check that:
+ * - frame finished (ex: if HEADERS frame, then on_headers_end() fired)
+ * - frame was in fact using the expected type and stream_id.
+ */
+int h2_decoded_frame_check_finished(
+    const struct h2_decoded_frame *frame,
+    enum aws_h2_frame_type expected_type,
+    uint32_t expected_stream_id);
+
+/**
+ * Translates decoder callbacks into an array-list of h2_decoded_frames.
+ */
+struct h2_decode_tester {
+    struct aws_allocator *alloc;
+    struct aws_h2_decoder *decoder;
+    struct aws_array_list frames; /* contains h2_decoded_frame */
+};
+
+struct h2_decode_tester_options {
+    struct aws_allocator *alloc;
+    bool is_server;
+    bool skip_connection_preface;
+};
+
+int h2_decode_tester_init(struct h2_decode_tester *decode_tester, const struct h2_decode_tester_options *options);
+void h2_decode_tester_clean_up(struct h2_decode_tester *decode_tester);
+
+size_t h2_decode_tester_frame_count(const struct h2_decode_tester *decode_tester);
+struct h2_decoded_frame *h2_decode_tester_get_frame(const struct h2_decode_tester *decode_tester, size_t i);
+struct h2_decoded_frame *h2_decode_tester_latest_frame(const struct h2_decode_tester *decode_tester);
+
+/**
+ * Compare data (which may be split across N frames) against expected
+ */
+int h2_decode_tester_check_data_across_frames(
+    const struct h2_decode_tester *decode_tester,
+    uint32_t stream_id,
+    struct aws_byte_cursor expected,
+    bool expect_end_stream);
+
+/**
+ * Compare data (which may be split across N frames) against expected
+ */
+int h2_decode_tester_check_data_str_across_frames(
+    const struct h2_decode_tester *decode_tester,
+    uint32_t stream_id,
+    const char *expected,
+    bool expect_end_stream);
+
+/**
+ * Fake HTTP/2 peer.
+ * Can decode H2 frames that are are written to the testing channel.
+ * Can encode H2 frames and push it into the channel in the read direction.
+ */
+struct h2_fake_peer {
+    struct aws_allocator *alloc;
+    struct testing_channel *testing_channel;
+
+    struct aws_h2_frame_encoder encoder;
+    struct h2_decode_tester decode;
+};
+
+struct h2_fake_peer_options {
+    struct aws_allocator *alloc;
+    struct testing_channel *testing_channel;
+    bool is_server;
+};
+
+int h2_fake_peer_init(struct h2_fake_peer *peer, const struct h2_fake_peer_options *options);
+void h2_fake_peer_clean_up(struct h2_fake_peer *peer);
+
+#endif /* AWS_HTTP_H2_TEST_HELPER_H */


### PR DESCRIPTION
Move code around so we can re-use helpers.

Most of this code was already reviewed here: https://github.com/awslabs/aws-c-http/pull/187

How to review this PR:
- First few files are just adding `const` to arguments
- `h2_test_helper.h/c`
  - `struct h2_decoded_frame` used to be `struct frame` in `test_h2_decoder.c`
  - `struct h2_decode_tester` used to be `struct fixture` in `test_h2_decoder.c`
  - `struct h2_fake_peer` is **NEW**
- `test_h2_client.c`: rewrote one test to use the helpers, instead of comparing against binary data I'd typed out by hand.
- `test_h2_decoder.c`: massive changes not worth looking at, it's just from me moving/renaming the code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
