### PR TITLE
remove h2_decoder_***_split_at_i tests.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,7 +16,6 @@ endmacro()
 macro(add_h2_decoder_test_set NAME)
     add_test_case("${NAME}")
     add_test_case("${NAME}_one_byte_at_a_time")
-    add_test_case("${NAME}_split_at_i")
 endmacro()
 
 add_test_case(headers_add)

--- a/tests/test_h2_decoder.c
+++ b/tests/test_h2_decoder.c
@@ -23,17 +23,10 @@ struct fixture {
     /* If true, run decoder over input one byte at a time */
     bool one_byte_at_a_time;
 
-    /* If set, run decoder over input in two chunks, divided at the split, and we test every possible split */
-    aws_test_run_fn *split_test_fn;
-    size_t split_i;
-    bool split_tests_complete;
-
     bool is_server;
     bool skip_connection_preface;
 };
 
-/* Note that init() and clean_up() are called multiple times in "split tests",
- * which re-runs the test at each possible split point */
 static int s_fixture_init(struct fixture *fixture, struct aws_allocator *allocator) {
     fixture->allocator = allocator;
 
@@ -71,34 +64,15 @@ static int s_fixture_test_teardown(struct aws_allocator *allocator, int setup_re
     return AWS_OP_SUCCESS;
 }
 
-/* Runs all "split_at_i" tests */
-static int s_test_splits(struct aws_allocator *allocator, void *ctx) {
-    struct fixture *fixture = ctx;
-
-    /* Run the named test, with a split at each possible byte, until s_decode_all() tells us that we're done */
-    for (size_t i = 1; !fixture->split_tests_complete; ++i) {
-        fixture->split_i = i;
-        AWS_LOGF_INFO(AWS_LS_COMMON_GENERAL, "Running split test at byte %zu", i);
-        ASSERT_SUCCESS(fixture->split_test_fn(fixture->allocator, fixture));
-
-        /* Reset state */
-        s_fixture_clean_up(fixture);
-        ASSERT_SUCCESS(s_fixture_init(fixture, allocator));
-    }
-
-    return AWS_OP_SUCCESS;
-}
-
 /* declare 1 test using the fixture */
 #define TEST_CASE(NAME)                                                                                                \
     static struct fixture s_fixture_##NAME;                                                                            \
     AWS_TEST_CASE_FIXTURE(NAME, s_fixture_test_setup, s_test_##NAME, s_fixture_test_teardown, &s_fixture_##NAME);      \
     static int s_test_##NAME(struct aws_allocator *allocator, void *ctx)
 
-/* declare 3 tests, where:
+/* declare 2 tests, where:
  * 1) NAME runs the decoder over input all at once
- * 2) NAME_one_byte_at_a_time runs the decoder on one byte of input at a time.
- * 3) NAME_split_at_i runs the decoder on input, split into two chunks. And re-runs test over every possible split */
+ * 2) NAME_one_byte_at_a_time runs the decoder on one byte of input at a time. */
 #define H2_DECODER_TEST_CASE_IMPL(NAME, IS_SERVER, SKIP_PREFACE)                                                       \
     static struct fixture s_fixture_##NAME = {                                                                         \
         .is_server = (IS_SERVER),                                                                                      \
@@ -115,18 +89,7 @@ static int s_test_splits(struct aws_allocator *allocator, void *ctx) {
         s_fixture_test_setup,                                                                                          \
         s_test_##NAME,                                                                                                 \
         s_fixture_test_teardown,                                                                                       \
-        &s_fixture_##NAME##_one_byte_at_a_time);                                                                       \
-    static struct fixture s_fixture_##NAME##_split_at_i = {                                                            \
-        .split_test_fn = s_test_##NAME,                                                                                \
-        .is_server = (IS_SERVER),                                                                                      \
-        .skip_connection_preface = (SKIP_PREFACE),                                                                     \
-    };                                                                                                                 \
-    AWS_TEST_CASE_FIXTURE(                                                                                             \
-        NAME##_split_at_i,                                                                                             \
-        s_fixture_test_setup,                                                                                          \
-        s_test_splits,                                                                                                 \
-        s_fixture_test_teardown,                                                                                       \
-        &s_fixture_##NAME##_split_at_i);                                                                               \
+        &s_fixture_##NAME##_one_byte_at_a_time)                                                                        \
     static int s_test_##NAME(struct aws_allocator *allocator, void *ctx)
 
 #define H2_DECODER_ON_CLIENT_TEST(NAME) H2_DECODER_TEST_CASE_IMPL(NAME, false /*server*/, true /*skip_preface*/)
@@ -153,25 +116,6 @@ static int s_decode_all(struct fixture *fixture, struct aws_byte_cursor input) {
             }
             ASSERT_UINT_EQUALS(0, one_byte.len);
         }
-
-    } else if (fixture->split_i) {
-        /* Decode input in 2 chunks, divided at the split */
-        ASSERT_TRUE(fixture->split_i < input.len);
-        if (fixture->split_i == input.len - 1) {
-            /* Inform the fixture that we've done every possible split */
-            fixture->split_tests_complete = true;
-        }
-
-        struct aws_byte_cursor first_chunk = aws_byte_cursor_advance(&input, fixture->split_i);
-        if (aws_h2_decode(fixture->decode.decoder, &first_chunk)) {
-            return AWS_OP_ERR;
-        }
-        ASSERT_UINT_EQUALS(0, first_chunk.len);
-
-        if (aws_h2_decode(fixture->decode.decoder, &input)) {
-            return AWS_OP_ERR;
-        }
-        ASSERT_UINT_EQUALS(0, input.len);
 
     } else {
         /* Decode buffer all at once */


### PR DESCRIPTION
Justification: Each h2-decoder test was run 3 different ways. This third way has never surfaced any new bugs and adds ~100 tests. aws-c-http has over 500 tests now and takes a while to run. Let's just remove these.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
