### PR TITLE
Automatically reject PUSH_PROMISE streams

### DIFF
--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -48,6 +48,9 @@ struct aws_h2_connection {
         /* My settings to send/sent to peer, which affects the decoding */
         uint32_t settings_self[AWS_H2_SETTINGS_END_RANGE];
 
+        /* Most recent stream-id that was initiated by peer */
+        uint32_t latest_peer_initiated_stream_id;
+
         /* Maps stream-id to aws_h2_stream*.
          * Contains all streams in the open, reserved, and half-closed states (terms from RFC-7540 5.1).
          * Once a stream enters closed state, it is removed from this map. */
@@ -114,6 +117,12 @@ struct aws_http_connection *aws_http_connection_new_http2_client(
     bool manual_window_management,
     size_t initial_window_size);
 
+/* Transform the request to h2 style headers */
+AWS_HTTP_API
+struct aws_http_headers *aws_h2_create_headers_from_request(
+    struct aws_http_message *request,
+    struct aws_allocator *alloc);
+
 AWS_EXTERN_C_END
 
 /* Private functions called from multiple .c files... */
@@ -141,12 +150,12 @@ int aws_h2_connection_on_stream_closed(
     enum aws_h2_stream_closed_when closed_when,
     int aws_error_code);
 
-AWS_EXTERN_C_BEGIN
-/* Transform the request to h2 style headers */
-AWS_HTTP_API
-struct aws_http_headers *aws_h2_create_headers_from_request(
-    struct aws_http_message *request,
-    struct aws_allocator *alloc);
+/**
+ * Send RST_STREAM and close a stream reserved via PUSH_PROMISE.
+ */
+int aws_h2_connection_send_rst_and_close_reserved_stream(
+    struct aws_h2_connection *connection,
+    uint32_t stream_id,
+    uint32_t h2_error_code);
 
-AWS_EXTERN_C_END
 #endif /* AWS_HTTP_H2_CONNECTION_H */

--- a/include/aws/http/private/h2_stream.h
+++ b/include/aws/http/private/h2_stream.h
@@ -104,6 +104,7 @@ int aws_h2_stream_on_decoder_headers_end(
     bool malformed,
     enum aws_http_header_block block_type);
 
+int aws_h2_stream_on_decoder_push_promise(struct aws_h2_stream *stream, uint32_t promised_stream_id);
 int aws_h2_stream_on_decoder_data(struct aws_h2_stream *stream, struct aws_byte_cursor data);
 int aws_h2_stream_on_decoder_end_stream(struct aws_h2_stream *stream);
 int aws_h2_stream_on_decoder_rst_stream(struct aws_h2_stream *stream, uint32_t h2_error_code);

--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -780,8 +780,8 @@ int s_decoder_on_headers_end(
 
 int s_decoder_on_push_promise(uint32_t stream_id, uint32_t promised_stream_id, void *userdata) {
     struct aws_h2_connection *connection = userdata;
-    AWS_ASSERT(connection->base.client_data); /* decoder enforces that server cannot receive PUSH_PROMISE */
-    AWS_ASSERT(promised_stream_id % 2 == 0);  /* decoder enforces that promised_stream_id is even-numbered */
+    AWS_ASSERT(connection->base.client_data); /* decoder has already enforced this */
+    AWS_ASSERT(promised_stream_id % 2 == 0);  /* decoder has already enforced this  */
 
     /* The identifier of a newly established stream MUST be numerically greater
      * than all streams that the initiating endpoint has opened or reserved (RFC-7540 5.1.1) */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -354,6 +354,7 @@ add_test_case(h2_client_stream_send_stalled_data)
 #TODO add_test_case(h2_client_stream_err_input_stream_failure)
 add_test_case(h2_client_stream_err_receive_rst_stream)
 add_test_case(h2_client_stream_receive_rst_stream_after_complete_response_ok)
+add_test_case(h2_client_push_promise_automatically_rejected)
 
 
 add_test_case(server_new_destroy)

--- a/tests/test_h2_client.c
+++ b/tests/test_h2_client.c
@@ -658,7 +658,7 @@ TEST_CASE(h2_client_stream_send_data) {
     ASSERT_NOT_NULL(request);
 
     struct aws_http_header request_headers_src[] = {
-        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":method", "POST"),
         DEFINE_HEADER(":scheme", "https"),
         DEFINE_HEADER(":path", "/"),
     };
@@ -741,17 +741,17 @@ TEST_CASE(h2_client_stream_send_lots_of_data) {
     struct aws_http_message *requests[NUM_STREAMS];
     struct aws_http_header request_headers_src[NUM_STREAMS][3] = {
         {
-            DEFINE_HEADER(":method", "GET"),
+            DEFINE_HEADER(":method", "POST"),
             DEFINE_HEADER(":scheme", "https"),
             DEFINE_HEADER(":path", "/a.txt"),
         },
         {
-            DEFINE_HEADER(":method", "GET"),
+            DEFINE_HEADER(":method", "POST"),
             DEFINE_HEADER(":scheme", "https"),
             DEFINE_HEADER(":path", "/b.txt"),
         },
         {
-            DEFINE_HEADER(":method", "GET"),
+            DEFINE_HEADER(":method", "POST"),
             DEFINE_HEADER(":scheme", "https"),
             DEFINE_HEADER(":path", "/c.txt"),
         },
@@ -874,7 +874,7 @@ TEST_CASE(h2_client_stream_send_stalled_data) {
     ASSERT_NOT_NULL(request);
 
     struct aws_http_header request_headers_src[] = {
-        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":method", "POST"),
         DEFINE_HEADER(":scheme", "https"),
         DEFINE_HEADER(":path", "/"),
     };
@@ -993,7 +993,7 @@ TEST_CASE(h2_client_stream_receive_rst_stream_after_complete_response_ok) {
     ASSERT_NOT_NULL(request);
 
     struct aws_http_header request_headers_src[] = {
-        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":method", "POST"),
         DEFINE_HEADER(":scheme", "https"),
         DEFINE_HEADER(":path", "/"),
     };
@@ -1045,5 +1045,103 @@ TEST_CASE(h2_client_stream_receive_rst_stream_after_complete_response_ok) {
     client_stream_tester_clean_up(&stream_tester);
     aws_http_message_release(request);
     aws_input_stream_destroy(request_body);
+    return s_tester_clean_up();
+}
+
+/* We don't fully support PUSH_PROMISE, so we automatically send RST_STREAM to reject any promised streams.
+ * Why, you ask, don't we simply send SETTINGS_ENABLE_PUSH=0 in the initial SETTINGS frame and call it a day?
+ * Because it's theoretically possible for a server to start sending PUSH_PROMISE frames in the initial
+ * response, before sending the ACK to the initial SETTINGS. */
+TEST_CASE(h2_client_push_promise_automatically_rejected) {
+    ASSERT_SUCCESS(s_tester_init(allocator, ctx));
+
+    /* fake peer sends connection preface */
+    ASSERT_SUCCESS(h2_fake_peer_send_connection_preface_default_settings(&s_tester.peer));
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+
+    /* send request */
+    struct aws_http_message *request = aws_http_message_new_request(allocator);
+    ASSERT_NOT_NULL(request);
+
+    struct aws_http_header request_headers_src[] = {
+        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":scheme", "https"),
+        DEFINE_HEADER(":authority", "veryblackpage.com"),
+        DEFINE_HEADER(":path", "/"),
+    };
+    aws_http_message_add_header_array(request, request_headers_src, AWS_ARRAY_SIZE(request_headers_src));
+
+    struct client_stream_tester stream_tester;
+    ASSERT_SUCCESS(s_stream_tester_init(&stream_tester, request));
+
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+    uint32_t stream_id = aws_http_stream_get_id(stream_tester.stream);
+
+    /* fake peer sends push request (PUSH_PROMISE) */
+    struct aws_http_header push_request_headers_src[] = {
+        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":scheme", "https"),
+        DEFINE_HEADER(":authority", "veryblackpage.com"),
+        DEFINE_HEADER(":path", "/style.css"),
+    };
+    struct aws_http_headers *push_request_headers = aws_http_headers_new(allocator);
+    ASSERT_SUCCESS(aws_http_headers_add_array(
+        push_request_headers, push_request_headers_src, AWS_ARRAY_SIZE(push_request_headers_src)));
+
+    uint32_t promised_stream_id = 2;
+    struct aws_h2_frame *peer_frame =
+        aws_h2_frame_new_push_promise(allocator, stream_id, promised_stream_id, push_request_headers, 0);
+    ASSERT_SUCCESS(h2_fake_peer_send_frame(&s_tester.peer, peer_frame));
+
+    /* fake peer sends push response RIGHT AWAY before there's any possibility of receiving RST_STREAM */
+    struct aws_http_header push_response_headers_src[] = {
+        DEFINE_HEADER(":status", "200"),
+    };
+    struct aws_http_headers *push_response_headers = aws_http_headers_new(allocator);
+    ASSERT_SUCCESS(aws_http_headers_add_array(
+        push_response_headers, push_response_headers_src, AWS_ARRAY_SIZE(push_response_headers_src)));
+
+    peer_frame =
+        aws_h2_frame_new_headers(allocator, promised_stream_id, push_response_headers, false /*end_stream*/, 0, NULL);
+    ASSERT_SUCCESS(h2_fake_peer_send_frame(&s_tester.peer, peer_frame));
+
+    ASSERT_SUCCESS(h2_fake_peer_send_data_frame_str(
+        &s_tester.peer, promised_stream_id, "body {background-color: black;}", true /*end_stream*/));
+
+    /* fake peer sends response to the initial request */
+    struct aws_http_header response_headers_src[] = {
+        DEFINE_HEADER(":status", "200"),
+    };
+    struct aws_http_headers *response_headers = aws_http_headers_new(allocator);
+    aws_http_headers_add_array(response_headers, response_headers_src, AWS_ARRAY_SIZE(response_headers_src));
+
+    peer_frame = aws_h2_frame_new_headers(allocator, stream_id, response_headers, false /*end_stream*/, 0, NULL);
+    ASSERT_SUCCESS(h2_fake_peer_send_frame(&s_tester.peer, peer_frame));
+
+    const char *body_src = "<html><head><link rel=\"stylesheet\" type=\"text/css\" href=\"style.css\"></head></html>";
+    ASSERT_SUCCESS(h2_fake_peer_send_data_frame_str(&s_tester.peer, stream_id, body_src, true /*end_stream*/));
+
+    /* validate that stream completed successfully. */
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+    ASSERT_TRUE(stream_tester.complete);
+    ASSERT_INT_EQUALS(AWS_ERROR_SUCCESS, stream_tester.on_complete_error_code);
+    ASSERT_INT_EQUALS(200, stream_tester.response_status);
+    ASSERT_BIN_ARRAYS_EQUALS(
+        body_src, strlen(body_src), stream_tester.response_body.buffer, stream_tester.response_body.len);
+
+    ASSERT_TRUE(aws_http_connection_is_open(s_tester.connection));
+
+    /* validate that client automatically sent RST_STREAM to reject the promised stream */
+    ASSERT_SUCCESS(h2_fake_peer_decode_messages_from_testing_channel(&s_tester.peer));
+    struct h2_decoded_frame *client_sent_rst_stream = h2_decode_tester_find_stream_frame(
+        &s_tester.peer.decode, AWS_H2_FRAME_T_RST_STREAM, promised_stream_id, 0, NULL);
+    ASSERT_NOT_NULL(client_sent_rst_stream);
+
+    /* clean up */
+    aws_http_headers_release(push_request_headers);
+    aws_http_headers_release(push_response_headers);
+    aws_http_headers_release(response_headers);
+    aws_http_message_release(request);
+    client_stream_tester_clean_up(&stream_tester);
     return s_tester_clean_up();
 }


### PR DESCRIPTION
Until we have a need for it, PUSH_PROMISE is not a fully supported feature. Therefore, promised streams are automatically rejected in a manner compliant with RFC-7540

Why, you ask, don't we simply send SETTINGS_ENABLE_PUSH=0 in the initial SETTINGS frame and call it a day? Because it's theoretically possible for a server to start sending PUSH_PROMISE frames in the initial response, before sending the ACK to the initial SETTINGS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
