### PR TITLE
internal settings change function

### DIFF
--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -48,6 +48,10 @@ struct aws_h2_connection {
         /* My settings to send/sent to peer, which affects the decoding */
         uint32_t settings_self[AWS_H2_SETTINGS_END_RANGE];
 
+        /* List using h2_pending_settings.node
+         * Contains settings waiting to be ACKed by peer and applied */
+        struct aws_linked_list pending_settings_self_list;
+
         /* Most recent stream-id that was initiated by peer */
         uint32_t latest_peer_initiated_stream_id;
 
@@ -150,6 +154,12 @@ struct aws_http_headers *aws_h2_create_headers_from_request(
 AWS_EXTERN_C_END
 
 /* Private functions called from multiple .c files... */
+
+/* Internal API for changing self settings of the connection */
+int aws_h2_connection_change_settings(
+    struct aws_h2_connection *connection,
+    const struct aws_h2_frame_setting *setting_array,
+    size_t num_settings);
 
 /**
  * Enqueue outgoing frame.

--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -50,7 +50,7 @@ struct aws_h2_connection {
 
         /* List using h2_pending_settings.node
          * Contains settings waiting to be ACKed by peer and applied */
-        struct aws_linked_list pending_settings_self_list;
+        struct aws_linked_list pending_settings_queue;
 
         /* Most recent stream-id that was initiated by peer */
         uint32_t latest_peer_initiated_stream_id;

--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -154,8 +154,6 @@ struct aws_h2_frame_encoder {
 
     /* Settings for frame encoder, which is based on the settings received from peer */
     struct {
-        /* the maximum size of the header compression table used to decode header blocks */
-        uint32_t header_table_size;
         /*  the size of the largest frame payload */
         uint32_t max_frame_size;
     } settings;

--- a/include/aws/http/private/h2_stream.h
+++ b/include/aws/http/private/h2_stream.h
@@ -78,7 +78,7 @@ struct aws_h2_stream *aws_h2_stream_new_request(
 
 enum aws_h2_stream_state aws_h2_stream_get_state(const struct aws_h2_stream *stream);
 
-int aws_h2_stream_window_size_change(struct aws_h2_stream *stream, int32_t size_changed, bool self);
+struct aws_h2err aws_h2_stream_window_size_change(struct aws_h2_stream *stream, int32_t size_changed, bool self);
 
 /* Connection is ready to send frames from stream now */
 int aws_h2_stream_on_activated(struct aws_h2_stream *stream, bool *out_has_outgoing_data);

--- a/include/aws/http/private/h2_stream.h
+++ b/include/aws/http/private/h2_stream.h
@@ -78,7 +78,7 @@ struct aws_h2_stream *aws_h2_stream_new_request(
 
 enum aws_h2_stream_state aws_h2_stream_get_state(const struct aws_h2_stream *stream);
 
-int aws_h2_stream_window_size_change(struct aws_h2_stream *stream, int32_t size_changed);
+int aws_h2_stream_window_size_change(struct aws_h2_stream *stream, int32_t size_changed, bool self);
 
 /* Connection is ready to send frames from stream now */
 int aws_h2_stream_on_activated(struct aws_h2_stream *stream, bool *out_has_outgoing_data);

--- a/include/aws/http/private/hpack.h
+++ b/include/aws/http/private/hpack.h
@@ -131,7 +131,7 @@ int aws_hpack_resize_dynamic_table(struct aws_hpack_context *context, size_t new
  * two header blocks. The dynamic table resize and the dynamic table size update entry will be handled properly when we
  * encode the next header block  */
 AWS_HTTP_API
-void aws_hpack_set_max_table_size(struct aws_hpack_context *context, size_t new_max_size);
+void aws_hpack_set_max_table_size(struct aws_hpack_context *context, size_t setting_max_size, bool update_table_size);
 
 AWS_HTTP_API
 void aws_hpack_set_huffman_mode(struct aws_hpack_context *context, enum aws_hpack_huffman_mode mode);

--- a/include/aws/http/private/hpack.h
+++ b/include/aws/http/private/hpack.h
@@ -131,7 +131,10 @@ int aws_hpack_resize_dynamic_table(struct aws_hpack_context *context, size_t new
  * two header blocks. The dynamic table resize and the dynamic table size update entry will be handled properly when we
  * encode the next header block  */
 AWS_HTTP_API
-void aws_hpack_set_max_table_size(struct aws_hpack_context *context, size_t setting_max_size, bool update_table_size);
+void aws_hpack_set_max_table_size(struct aws_hpack_context *context, uint32_t new_max_size);
+
+AWS_HTTP_API
+void aws_hpack_set_protocol_max_size_setting(struct aws_hpack_context *context, uint32_t setting_max_size);
 
 AWS_HTTP_API
 void aws_hpack_set_huffman_mode(struct aws_hpack_context *context, enum aws_hpack_huffman_mode mode);

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -1534,6 +1534,9 @@ static struct aws_h2err s_state_fn_connection_preface_string(
 }
 
 void aws_h2_decoder_set_setting_header_table_size(struct aws_h2_decoder *decoder, uint32_t data) {
+    /* Set the max_dynamic_table_size for hpack, but we will not update the dynamic table size until we receive dynamic
+     * table size update from header block */
+    aws_hpack_set_max_table_size(decoder->hpack, data, false /*udpate table size*/);
     decoder->settings.header_table_size = data;
 }
 

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -1531,8 +1531,7 @@ static struct aws_h2err s_state_fn_connection_preface_string(
 }
 
 void aws_h2_decoder_set_setting_header_table_size(struct aws_h2_decoder *decoder, uint32_t data) {
-    /* Set the max_dynamic_table_size for hpack, but we will not update the dynamic table size until we receive dynamic
-     * table size update from header block */
+    /* Set the protocol_max_size_setting for hpack. */
     aws_hpack_set_protocol_max_size_setting(decoder->hpack, data);
 }
 

--- a/source/h2_decoder.c
+++ b/source/h2_decoder.c
@@ -270,8 +270,6 @@ struct aws_h2_decoder {
 
     /* Settings for decoder, which is based on the settings sent to the peer and ACKed by peer */
     struct {
-        /* the maximum size of the header compression table used to decode header blocks */
-        uint32_t header_table_size;
         /* enable/disable server push */
         uint32_t enable_push;
         /*  the size of the largest frame payload */
@@ -326,7 +324,6 @@ struct aws_h2_decoder *aws_h2_decoder_new(struct aws_h2_decoder_params *params) 
         decoder->state = &s_state_prefix;
     }
 
-    decoder->settings.header_table_size = aws_h2_settings_initial[AWS_H2_SETTINGS_HEADER_TABLE_SIZE];
     decoder->settings.enable_push = aws_h2_settings_initial[AWS_H2_SETTINGS_ENABLE_PUSH];
     decoder->settings.max_frame_size = aws_h2_settings_initial[AWS_H2_SETTINGS_MAX_FRAME_SIZE];
 
@@ -1536,8 +1533,7 @@ static struct aws_h2err s_state_fn_connection_preface_string(
 void aws_h2_decoder_set_setting_header_table_size(struct aws_h2_decoder *decoder, uint32_t data) {
     /* Set the max_dynamic_table_size for hpack, but we will not update the dynamic table size until we receive dynamic
      * table size update from header block */
-    aws_hpack_set_max_table_size(decoder->hpack, data, false /*udpate table size*/);
-    decoder->settings.header_table_size = data;
+    aws_hpack_set_protocol_max_size_setting(decoder->hpack, data);
 }
 
 void aws_h2_decoder_set_setting_enable_push(struct aws_h2_decoder *decoder, uint32_t data) {

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -312,7 +312,6 @@ int aws_h2_frame_encoder_init(
         return AWS_OP_ERR;
     }
 
-    encoder->settings.header_table_size = aws_h2_settings_initial[AWS_H2_SETTINGS_HEADER_TABLE_SIZE];
     encoder->settings.max_frame_size = aws_h2_settings_initial[AWS_H2_SETTINGS_MAX_FRAME_SIZE];
     return AWS_OP_SUCCESS;
 }
@@ -1227,10 +1226,10 @@ int aws_h2_encode_frame(
 }
 
 void aws_h2_frame_encoder_set_setting_header_table_size(struct aws_h2_frame_encoder *encoder, uint32_t data) {
-    /* Setting for dynamic table size changed from peer, we will udpate the dynamic table size when we encoder the next
+    /* Setting for dynamic table size changed from peer, we will update the dynamic table size when we encoder the next
      * header block */
-    aws_hpack_set_max_table_size(encoder->hpack, data, true /*udpate table size*/);
-    encoder->settings.header_table_size = data;
+    aws_hpack_set_max_table_size(encoder->hpack, data);
+    aws_hpack_set_protocol_max_size_setting(encoder->hpack, data);
 }
 
 void aws_h2_frame_encoder_set_setting_max_frame_size(struct aws_h2_frame_encoder *encoder, uint32_t data) {

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -1227,7 +1227,9 @@ int aws_h2_encode_frame(
 }
 
 void aws_h2_frame_encoder_set_setting_header_table_size(struct aws_h2_frame_encoder *encoder, uint32_t data) {
-    aws_hpack_set_max_table_size(encoder->hpack, data);
+    /* Setting for dynamic table size changed from peer, we will udpate the dynamic table size when we encoder the next
+     * header block */
+    aws_hpack_set_max_table_size(encoder->hpack, data, true /*udpate table size*/);
     encoder->settings.header_table_size = data;
 }
 

--- a/source/hpack.c
+++ b/source/hpack.c
@@ -248,7 +248,7 @@ struct aws_hpack_context {
         size_t size;
         size_t max_size;
 
-        /* SETTINGS_HEARDER_TABLE_SIZE from http2 */
+        /* SETTINGS_HEADER_TABLE_SIZE from http2 */
         size_t protocol_max_size_setting;
         /* aws_http_header * -> size_t */
         struct aws_hash_table reverse_lookup;
@@ -786,15 +786,17 @@ error:
     return AWS_OP_ERR;
 }
 
-void aws_hpack_set_max_table_size(struct aws_hpack_context *context, size_t setting_max_size, bool update_table_size) {
-    if (update_table_size) {
-        if (!context->dynamic_table_size_update.pending) {
-            context->dynamic_table_size_update.pending = true;
-        }
-        context->dynamic_table_size_update.smallest_value =
-            aws_min_size(setting_max_size, context->dynamic_table_size_update.smallest_value);
-        context->dynamic_table_size_update.last_value = setting_max_size;
+void aws_hpack_set_max_table_size(struct aws_hpack_context *context, uint32_t new_max_size) {
+
+    if (!context->dynamic_table_size_update.pending) {
+        context->dynamic_table_size_update.pending = true;
     }
+    context->dynamic_table_size_update.smallest_value =
+        aws_min_size(new_max_size, context->dynamic_table_size_update.smallest_value);
+    context->dynamic_table_size_update.last_value = new_max_size;
+}
+
+void aws_hpack_set_protocol_max_size_setting(struct aws_hpack_context *context, uint32_t setting_max_size) {
     context->dynamic_table.protocol_max_size_setting = setting_max_size;
 }
 

--- a/tests/test_hpack.c
+++ b/tests/test_hpack.c
@@ -835,9 +835,9 @@ static int test_hpack_dynamic_table_size_update_from_setting(struct aws_allocato
     ASSERT_NOT_NULL(context);
 
     /* let's pretent multiple times max size update happened from encoder setting */
-    aws_hpack_set_max_table_size(context, 10, true /*udpate table size*/);
-    aws_hpack_set_max_table_size(context, 0, true /*udpate table size*/);
-    aws_hpack_set_max_table_size(context, 1337, true /*udpate table size*/);
+    aws_hpack_set_max_table_size(context, 10);
+    aws_hpack_set_max_table_size(context, 0);
+    aws_hpack_set_max_table_size(context, 1337);
 
     /* encode a header block */
     struct aws_http_headers *headers = aws_http_headers_new(allocator);

--- a/tests/test_hpack.c
+++ b/tests/test_hpack.c
@@ -835,9 +835,9 @@ static int test_hpack_dynamic_table_size_update_from_setting(struct aws_allocato
     ASSERT_NOT_NULL(context);
 
     /* let's pretent multiple times max size update happened from encoder setting */
-    aws_hpack_set_max_table_size(context, 10);
-    aws_hpack_set_max_table_size(context, 0);
-    aws_hpack_set_max_table_size(context, 1337);
+    aws_hpack_set_max_table_size(context, 10, true /*udpate table size*/);
+    aws_hpack_set_max_table_size(context, 0, true /*udpate table size*/);
+    aws_hpack_set_max_table_size(context, 1337, true /*udpate table size*/);
 
     /* encode a header block */
     struct aws_http_headers *headers = aws_http_headers_new(allocator);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- settings change from internal.
- create a queue for pending settings
- when we want to change our settings, we send a setting frame to our peer, then push the pending settings to the back of the queue.
- when the setting ACK is received from the peer, we pop the front one from the queue, and apply the settings to our connection.