### PR TITLE
Fix refcounting bug in h2_connection.c

### DIFF
--- a/include/aws/http/private/h2_connection.h
+++ b/include/aws/http/private/h2_connection.h
@@ -99,12 +99,6 @@ struct aws_h2_connection {
 
     /* Any thread may touch this data, but the lock must be held (unless it's an atomic) */
     struct {
-        /* For checking status from outside the event-loop thread. */
-        struct aws_atomic_var is_open;
-
-        /* If non-zero, reason to immediately reject new streams. (ex: closing) */
-        struct aws_atomic_var new_stream_error_code;
-
         struct aws_mutex lock;
 
         /* New `aws_h2_stream *` that haven't moved to `thread_data` yet */
@@ -113,6 +107,14 @@ struct aws_h2_connection {
         bool is_cross_thread_work_task_scheduled;
 
     } synced_data;
+
+    struct {
+        /* For checking status from outside the event-loop thread. */
+        struct aws_atomic_var is_open;
+
+        /* If non-zero, reason to immediately reject new streams. (ex: closing) */
+        struct aws_atomic_var new_stream_error_code;
+    } atomic;
 };
 
 /**

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -455,7 +455,7 @@ int aws_h1_stream_activate(struct aws_http_stream *stream) {
         return AWS_OP_ERR;
     }
 
-    /* activate one more time now that the connection can actually run the stream. */
+    /* connection keeps activated stream alive until stream completes */
     aws_atomic_fetch_add(&stream->refcount, 1);
 
     if (should_schedule_task) {


### PR DESCRIPTION
- aws_stream_activate() should be increment stream refcount, not the function that moves it to a thread.
    - rename `s_stream_activate()` -> `s_move_stream_to_thread()` so it's not confused with `aws_h2_stream_activate()`
- reduce number of times we load atomic `new_stream_error_code`.
    - moved atomics out of `synced_data` to reduce confusion



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
