### PR TITLE
Suppress compiler warning C4232 for MSVC

### DIFF
--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -65,6 +65,7 @@ extern const uint32_t aws_h2_settings_initial[AWS_HTTP2_SETTINGS_END_RANGE];
 
 /* This magic string must be the very first thing a client sends to the server.
  * See RFC-7540 3.5 - HTTP/2 Connection Preface */
+AWS_HTTP_API
 extern const struct aws_byte_cursor aws_h2_connection_preface_client_string;
 
 /**

--- a/include/aws/http/private/h2_frames.h
+++ b/include/aws/http/private/h2_frames.h
@@ -64,7 +64,8 @@ AWS_HTTP_API
 extern const uint32_t aws_h2_settings_initial[AWS_HTTP2_SETTINGS_END_RANGE];
 
 /* This magic string must be the very first thing a client sends to the server.
- * See RFC-7540 3.5 - HTTP/2 Connection Preface */
+ * See RFC-7540 3.5 - HTTP/2 Connection Preface.
+ * Exported for tests */
 AWS_HTTP_API
 extern const struct aws_byte_cursor aws_h2_connection_preface_client_string;
 

--- a/source/connection.c
+++ b/source/connection.c
@@ -22,6 +22,7 @@
 
 #if _MSC_VER
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
+#    pragma warning(disable : 4232) /* function pointer to dll symbol */
 #endif
 
 static struct aws_http_connection_system_vtable s_default_system_vtable = {

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -23,6 +23,10 @@
 #include <aws/common/mutex.h>
 #include <aws/common/string.h>
 
+#if _MSC_VER
+#    pragma warning(disable : 4232) /* function pointer to dll symbol */
+#endif
+
 /*
  * Established connections not currently in use are tracked via this structure.
  */

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -23,7 +23,6 @@
 
 #define ENCODER_LOG(level, encoder, text) ENCODER_LOGF(level, encoder, "%s", text)
 
-/* exported for tests */
 const struct aws_byte_cursor aws_h2_connection_preface_client_string =
     AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -24,7 +24,7 @@
 #define ENCODER_LOG(level, encoder, text) ENCODER_LOGF(level, encoder, "%s", text)
 
 /* exported for tests */
-AWS_HTTP_API const struct aws_byte_cursor aws_h2_connection_preface_client_string =
+const struct aws_byte_cursor aws_h2_connection_preface_client_string =
     AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n");
 
 /* Initial values and bounds are from RFC-7540 6.5.2 */

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -16,6 +16,7 @@
 
 #if _MSC_VER
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
+#    pragma warning(disable : 4232) /* function pointer to dll symbol */
 #endif
 
 AWS_STATIC_STRING_FROM_LITERAL(s_host_header_name, "Host");


### PR DESCRIPTION
**Issue:**
Encountered compiler warning [C4232](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4232?view=vs-2019) when building aws-c-http as shared library on Windows:
> nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed.

The following definitions are impacted:
```c
/* In connection.c */
static struct aws_http_connection_system_vtable s_default_system_vtable = {
    .new_socket_channel = aws_client_bootstrap_new_socket_channel,
};
```
```c
/* In proxy_connection.c */
static struct aws_http_proxy_system_vtable s_default_vtable = {
    .setup_client_tls = &aws_channel_setup_client_tls,
};
```
```c
/* In connection_manager.c */
static struct aws_http_connection_manager_system_vtable s_default_system_vtable = {
    ...
    .get_monotonic_time = aws_high_res_clock_get_ticks,
    .is_callers_thread = aws_channel_thread_is_callers_thread,
    ...
};
```
**Description of changes:**
Disable warning C4232 before using function pointer to dll symbol.
```c
#if _MSC_VER
#    pragma warning(disable : 4232) /* function pointer to dll symbol */
#endif
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
