### PR TITLE
HTTP/1 queues all read aws_io_messages before processing.

### DIFF
--- a/include/aws/http/private/h1_connection.h
+++ b/include/aws/http/private/h1_connection.h
@@ -64,12 +64,16 @@ struct aws_h1_connection {
         /* Used to encode requests and responses */
         struct aws_h1_encoder encoder;
 
-        /* Amount to let read-window shrink after a channel message has been processed. */
-        size_t incoming_message_window_shrink_size;
+        size_t body_bytes_decoded;
 
-        /* Messages received after the connection has switched protocols.
-         * These are passed downstream to the next handler. */
-        struct aws_linked_list midchannel_read_messages;
+        /* All aws_io_messages arriving in the read direction are queued here before processing.
+         * The downstream window (window of next handler, or window of incoming stream)
+         * determines how much data can be processed. The `copy_mark` is used to
+         * track progress on partially processed messages at the front of the queue. */
+        struct {
+            struct aws_linked_list messages;
+            /* TODO: more variables will go in this struct in the near-future */
+        } read_buffer;
 
         struct aws_crt_statistics_http1_channel stats;
 

--- a/tests/test_h1_client.c
+++ b/tests/test_h1_client.c
@@ -2722,7 +2722,9 @@ static int s_error_from_outgoing_body_read(struct aws_input_stream *body, struct
     (void)dest;
 
     struct error_from_callback_tester *error_tester = body->impl;
-    ASSERT_SUCCESS(s_error_from_callback_common(error_tester, REQUEST_CALLBACK_OUTGOING_BODY));
+    if (s_error_from_callback_common(error_tester, REQUEST_CALLBACK_OUTGOING_BODY)) {
+        return AWS_OP_ERR;
+    }
 
     /* If the common fn was successful, write out some data and end the stream */
     ASSERT_TRUE(aws_byte_buf_write(dest, (const uint8_t *)"abcd", 4));


### PR DESCRIPTION
Also break up giant process_read_message() function into smaller chunks.

Previously, we were only queueing messages after switching protocols and becoming a midchannel handler. Now we always queue messages before processing them.

This is in preparation for changing how windows work in HTTP/1. We might need to buffer up read messages if the HTTP-stream's window is too small.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
