### PR TITLE
Add aws_connection_manager_new error logging

### DIFF
--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -760,14 +760,20 @@ struct aws_http_connection_manager *aws_http_connection_manager_new(
 
     aws_http_fatal_assert_library_initialized();
 
-    if (!options || !options->socket_options || options->max_connections == 0) {
+    if (!options) {
+        AWS_LOGF_ERROR(AWS_LS_HTTP_CONNECTION_MANAGER, "Invalid options - options is null");
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         return NULL;
     }
 
-    if (options->monitoring_options && !aws_http_connection_monitoring_options_is_valid(options->monitoring_options)) {
-        AWS_LOGF_ERROR(
-            AWS_LS_HTTP_CONNECTION_MANAGER, "(static) invalid monitoring options for connection manager creation");
+    if (!options->socket_options) {
+        AWS_LOGF_ERROR(AWS_LS_HTTP_CONNECTION_MANAGER, "Invalid options - socket_options is null");
+        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+        return NULL;
+    }
+
+    if (options->max_connections == 0) {
+        AWS_LOGF_ERROR(AWS_LS_HTTP_CONNECTION_MANAGER, "Invalid options - max_connections cannot be 0");
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         return NULL;
     }


### PR DESCRIPTION
*Description of changes:*

To improve debugging, split the error check into three separate checks, each with their own logging. This follows the style specified in c-common.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
