### PR TITLE
undef debug token before we use it, so swiftpm doesn't break the build.

### DIFF
--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -17,6 +17,7 @@
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
+/* Apple toolchains such as xcode and swiftpm define the DEBUG symbol. undef it here so we can actually use the token */
 #undef DEBUG
 
 #define CONNECTION_LOGF(level, connection, text, ...)                                                                  \

--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -17,6 +17,8 @@
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
+#undef DEBUG
+
 #define CONNECTION_LOGF(level, connection, text, ...)                                                                  \
     AWS_LOGF_##level(AWS_LS_HTTP_CONNECTION, "id=%p: " text, (void *)(connection), __VA_ARGS__)
 #define CONNECTION_LOG(level, connection, text) CONNECTION_LOGF(level, connection, "%s", text)

--- a/source/h2_stream.c
+++ b/source/h2_stream.c
@@ -11,6 +11,7 @@
 #include <aws/io/channel.h>
 #include <aws/io/logging.h>
 
+/* Apple toolchains such as xcode and swiftpm define the DEBUG symbol. undef it here so we can actually use the token */
 #undef DEBUG
 
 static void s_stream_destroy(struct aws_http_stream *stream_base);

--- a/source/h2_stream.c
+++ b/source/h2_stream.c
@@ -11,6 +11,8 @@
 #include <aws/io/channel.h>
 #include <aws/io/logging.h>
 
+#undef DEBUG
+
 static void s_stream_destroy(struct aws_http_stream *stream_base);
 static void s_stream_update_window(struct aws_http_stream *stream_base, size_t increment_size);
 static int s_stream_reset_stream(struct aws_http_stream *stream_base, uint32_t http2_error);


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
