### PR TITLE
tests: Fix multiple definition of s_tester varaible.

### DIFF
--- a/tests/test_h1_server.c
+++ b/tests/test_h1_server.c
@@ -51,7 +51,7 @@ struct tester_request {
 };
 
 /* Singleton used by tests in this file */
-struct tester {
+static struct tester {
     struct aws_allocator *alloc;
     struct aws_logger logger;
 

--- a/tests/test_h2_client.c
+++ b/tests/test_h2_client.c
@@ -62,7 +62,7 @@ static void s_on_remote_settings_change(
 }
 
 /* Singleton used by tests in this file */
-struct tester {
+static struct tester {
     struct aws_allocator *alloc;
     struct aws_http_connection *connection;
     struct testing_channel testing_channel;


### PR DESCRIPTION
The same variable is used in test_h2_client.c and test_h1_server.c file.