### PR TITLE
Stop using deprecated aws_off_t

### DIFF
--- a/tests/h2_test_helper.c
+++ b/tests/h2_test_helper.c
@@ -666,7 +666,7 @@ struct aws_input_stream_tester {
 
 static int s_aws_input_stream_tester_seek(
     struct aws_input_stream *stream,
-    aws_off_t offset,
+    int64_t offset,
     enum aws_stream_seek_basis basis) {
 
     struct aws_input_stream_tester *impl = stream->impl;


### PR DESCRIPTION
related:
https://github.com/awslabs/aws-c-common/pull/808
https://github.com/awslabs/aws-c-io/pull/386

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
