### PR TITLE
Hooking up tls connection options validity check

### DIFF
--- a/source/connection.c
+++ b/source/connection.c
@@ -873,6 +873,11 @@ static int s_validate_http_client_connection_options(const struct aws_http_clien
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
+    if (options->tls_options && !aws_tls_connection_options_is_valid(options->tls_options)) {
+        AWS_LOGF_ERROR(AWS_LS_HTTP_CONNECTION, "static: Invalid connection options, invalid TLS options");
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
+
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,6 +147,7 @@ add_test_case(strutil_is_http_request_target)
 
 add_net_test_case(tls_download_medium_file_h1)
 add_net_test_case(tls_download_medium_file_h2)
+add_net_test_case(tls_invalid_tls_connection_options)
 
 add_test_case(websocket_decoder_sanity_check)
 add_test_case(websocket_decoder_simplest_frame)


### PR DESCRIPTION
*Description of changes:*
Preventing opening of connection if TLS connection options are invalid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
