### PR TITLE
Fix GCC11 warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,18 +146,3 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} downstream
-
-  cross_compile:
-    name: Cross Compile ${{matrix.arch}}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [linux-armv6, linux-armv7, linux-arm64, android-armv7]
-
-    steps:
-    - name: Build ${{ env.PACKAGE_NAME }} + consumers
-      run: |
-        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
-        chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --target=${{matrix.arch}} run_tests=false
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - '!main'
 
 env:
-  BUILDER_VERSION: v0.8.9
+  BUILDER_VERSION: v0.8.11
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http
@@ -147,4 +147,17 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} downstream
 
+  cross_compile:
+    name: Cross Compile ${{matrix.arch}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [linux-armv6, linux-armv7, linux-arm64, android-armv7]
+
+    steps:
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream --target=${{matrix.arch}} run_tests=false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - '!main'
 
 env:
-  BUILDER_VERSION: v0.8.11
+  BUILDER_VERSION: v0.8.9
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http
@@ -146,3 +146,5 @@ jobs:
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} downstream
+
+

--- a/source/websocket.c
+++ b/source/websocket.c
@@ -1631,7 +1631,7 @@ void aws_websocket_increment_read_window(struct aws_websocket *websocket, size_t
 int aws_websocket_random_handshake_key(struct aws_byte_buf *dst) {
     /* RFC-6455 Section 4.1.
      * Derive random 16-byte value, base64-encoded, for the Sec-WebSocket-Key header */
-    uint8_t key_random_storage[16];
+    uint8_t key_random_storage[16] = {0};
     struct aws_byte_buf key_random_buf = aws_byte_buf_from_empty_array(key_random_storage, sizeof(key_random_storage));
     int err = aws_device_random_buffer(&key_random_buf);
     if (err) {

--- a/source/websocket_encoder.c
+++ b/source/websocket_encoder.c
@@ -80,7 +80,7 @@ static int s_state_length_byte(struct aws_websocket_encoder *encoder, struct aws
 /* STATE_EXTENDED_LENGTH: Output extended length (state skipped if not using extended length). */
 static int s_state_extended_length(struct aws_websocket_encoder *encoder, struct aws_byte_buf *out_buf) {
     /* Fill tmp buffer with extended-length in network byte order */
-    uint8_t network_bytes_array[8];
+    uint8_t network_bytes_array[8] = {0};
     struct aws_byte_buf network_bytes_buf =
         aws_byte_buf_from_empty_array(network_bytes_array, sizeof(network_bytes_array));
     if (encoder->frame.payload_length <= AWS_WEBSOCKET_2BYTE_EXTENDED_LENGTH_MAX_VALUE) {


### PR DESCRIPTION
GCC doesn't like buffers to be uninitialized before you fill them with random data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
