### PR TITLE
Use relative paths so that downstream builds of aws-c-http don't fail

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -14,7 +14,7 @@
         { "name": "aws-c-auth" }
     ],
     "test_steps": [
-        ["bash", "{project_dir}/.builder/action/aws-c-http-test.sh"],
-        ["{python}", "{project_dir}/integration-testing/http_client_test.py", "{install_dir}/bin/elasticurl{exe}"]
+        ["bash", "./.builder/action/aws-c-http-test.sh"],
+        ["{python}", "./integration-testing/http_client_test.py", "{install_dir}/bin/elasticurl{exe}"]
     ]
 }


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
