### PR TITLE
Upstream builds contain the build output in a different relative directory than direct builds

### DIFF
--- a/.builder/action/aws-c-http-test.sh
+++ b/.builder/action/aws-c-http-test.sh
@@ -2,8 +2,21 @@ PROXY_SETUP=/tmp/setup_proxy_test_env.sh
 if [ -f "$PROXY_SETUP" ]; then
     source $PROXY_SETUP
     export AWS_PROXY_NO_VERIFY_PEER=on
-    echo "setting proxy integration test envrionment"
+    echo "setting proxy integration test environment"
 fi
 
-cd ./build/aws-c-http/
+pushd
+
+if [ -d "./build/aws-c-http/"]; then
+    # This is the directory (relative to repo root) that will contain the build when the repo is built directly by the
+    # builder
+    cd ./build/aws-c-http/
+elif [ -d "../../aws-c-http"]; then
+    # This is the directory (relative to repo root) that will contain the build when the repo is built as an upstream
+    # consumer
+    cd ../../aws-c-http
+fi
+
 ctest --output-on-failure
+
+popd


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
