### PR TITLE
Fix refcount issue

### DIFF
--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -1524,13 +1524,9 @@ static void s_cull_idle_connections(struct aws_http_connection_manager *manager)
                 (void *)manager,
                 (void *)current_idle_connection->connection);
         }
-        s_aws_http_connection_manager_get_snapshot(manager, &work.snapshot);
-    } else {
-        AWS_LOGF_TRACE(
-            AWS_LS_HTTP_CONNECTION_MANAGER,
-            "id=%p: culling idle connections while manager shutting down. Do nothing",
-            (void *)manager);
     }
+
+    s_aws_http_connection_manager_get_snapshot(manager, &work.snapshot);
 
     aws_mutex_unlock(&manager->lock);
 

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -176,6 +176,7 @@ struct aws_http_connection_manager {
     /*
      * The number of all established, idle connections.  So
      * that we don't have compute the size of a linked list every time.
+     * It doesn't contribute to internal refcount as AWS_HCMCT_OPEN_CONNECTION inclues all idle connections as well.
      */
     size_t idle_connection_count;
 
@@ -218,6 +219,8 @@ struct aws_http_connection_manager {
 
     /*
      * The number of established new HTTP/2 connections we have waiting for SETTINGS from the http layer
+     * It doesn't contribute to internal refcount as AWS_HCMCT_OPEN_CONNECTION inclues all connections waiting for
+     * settings as well.
      */
     size_t pending_settings_count;
 

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -935,6 +935,7 @@ void aws_http_connection_manager_release(struct aws_http_connection_manager *man
                 "id=%p: ref count now zero, starting shut down process",
                 (void *)manager);
             manager->state = AWS_HCMST_SHUTTING_DOWN;
+            s_aws_http_connection_manager_build_transaction(&work);
             if (manager->cull_event_loop != NULL) {
                 /* When manager shutting down, schedule the task to cancel the cull task if exist. */
                 AWS_FATAL_ASSERT(manager->cull_task);
@@ -943,7 +944,6 @@ void aws_http_connection_manager_release(struct aws_http_connection_manager *man
                 aws_task_init(final_destruction_task, s_final_destruction_task, manager, "final_scheduled_destruction");
                 aws_event_loop_schedule_task_now(manager->cull_event_loop, final_destruction_task);
             }
-            s_aws_http_connection_manager_build_transaction(&work);
             aws_ref_count_release(&manager->internal_ref_count);
         }
     } else {

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -930,7 +930,6 @@ on_error:
 
 void aws_http_connection_manager_acquire(struct aws_http_connection_manager *manager) {
     aws_mutex_lock(&manager->lock);
-    aws_ref_count_acquire(&manager->internal_ref_count);
     AWS_FATAL_ASSERT(manager->external_ref_count > 0);
     manager->external_ref_count += 1;
     aws_mutex_unlock(&manager->lock);

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -1190,6 +1190,7 @@ void aws_http_connection_manager_acquire_connection(
     s_aws_http_connection_manager_execute_transaction(&work);
 }
 
+/* Only invoke with lock held */
 static int s_idle_connection(struct aws_http_connection_manager *manager, struct aws_http_connection *connection) {
     struct aws_idle_connection *idle_connection =
         aws_mem_calloc(manager->allocator, 1, sizeof(struct aws_idle_connection));

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -781,6 +781,7 @@ static void s_schedule_connection_culling(struct aws_http_connection_manager *ma
          */
         uint64_t now = 0;
         if (manager->system_vtable->get_monotonic_time(&now)) {
+            aws_mutex_unlock(&manager->lock);
             goto on_error;
         }
         cull_task_time =
@@ -795,6 +796,7 @@ static void s_schedule_connection_culling(struct aws_http_connection_manager *ma
 
 on_error:
 
+    aws_ref_count_release(&manager->internal_ref_count);
     manager->cull_event_loop = NULL;
     aws_mem_release(manager->allocator, manager->cull_task);
     manager->cull_task = NULL;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -469,6 +469,7 @@ add_net_test_case(test_connection_manager_proxy_setup_shutdown)
 add_net_test_case(test_connection_manager_idle_culling_single)
 add_net_test_case(test_connection_manager_idle_culling_many)
 add_net_test_case(test_connection_manager_idle_culling_mixture)
+add_net_test_case(test_connection_manager_idle_culling_refcount)
 
 # tests where we establish real connections
 add_net_test_case(test_connection_manager_single_connection)

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -1122,8 +1122,8 @@ static int s_test_connection_manager_idle_culling_mixture(struct aws_allocator *
 AWS_TEST_CASE(test_connection_manager_idle_culling_mixture, s_test_connection_manager_idle_culling_mixture);
 
 /**
- * Once upon time, if the cullign test is running while the connection manager is shutting, the refcount will be messed
- * up
+ * Once upon time, if the culling test is running while the connection manager is shutting, the refcount will be messed
+ * up (back from zero to one and trigger the destroy to happen twice)
  */
 static int s_test_connection_manager_idle_culling_refcount(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -1130,7 +1130,7 @@ static int s_test_connection_manager_idle_culling_refcount(struct aws_allocator 
 
     aws_http_library_init(allocator);
     for (size_t i = 0; i < 10; i++) {
-        /* To reproduce that more stable, repeat it 100 times. */
+        /* To reproduce that more stable, repeat it 10 times. */
         struct cm_tester_options options = {
             .allocator = allocator,
             .max_connections = 10,

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -1124,7 +1124,7 @@ AWS_TEST_CASE(test_connection_manager_idle_culling_mixture, s_test_connection_ma
 static int s_test_connection_manager_idle_culling_refcount(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t i = 0; i < 10; i++) {
         /* To reproduce that more stable, repeat it 100 times. */
         struct cm_tester_options options = {
             .allocator = allocator,


### PR DESCRIPTION
*Issue #, if available:*

- While connection manager is closing, if the culling task runs, it will increase the refcount back from zero, and decrease it after the task, which will let the clean up happen twice.
- A bug while acquire the external refcount should NOT acquire the internal refcount.

*Description of changes:*

- Culling task hold internal refcount, and cancel the task when the external refcount drops to zero instead of the internal refcount.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
