### PR TITLE
Fix our CI ignores branches that have "/" in name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches:
-      - '*'
-      - '!main'
+    branches-ignore:
+      - 'main'
 
 env:
   BUILDER_VERSION: v0.9.15


### PR DESCRIPTION
Fix our CI ignore branches that have / in name

this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
