### PR TITLE
Stream manager test with body

### DIFF
--- a/include/aws/http/http2_stream_manager.h
+++ b/include/aws/http/http2_stream_manager.h
@@ -64,8 +64,8 @@ struct aws_http2_stream_manager_options {
      * - By default, client will will maintain its flow-control windows such that no back-pressure is applied and data
      * arrives as fast as possible.
      * - For connection level window control, `conn_manual_window_management` will enable manual control. The
-     * inital window size is not controlable.
-     * - For stream level window control, `enable_read_back_pressure` will enable manual control. The initail window
+     * inital window size is not controllable.
+     * - For stream level window control, `enable_read_back_pressure` will enable manual control. The initial window
      * size needs to be set through `initial_settings_array`.
      */
     struct aws_http2_setting *initial_settings_array;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -620,6 +620,7 @@ if (ENABLE_LOCALHOST_INTEGRATION_TESTS)
     # Tests should be named with localhost_integ_*
     add_net_test_case(localhost_integ_h2_sm_prior_knowledge)
     add_net_test_case(localhost_integ_h2_sm_acquire_stream_stress)
+    add_net_test_case(localhost_integ_h2_sm_acquire_stream_stress_with_body)
 endif()
 
 add_test_case(random_access_set_sanitize_test)

--- a/tests/py_localhost/server.py
+++ b/tests/py_localhost/server.py
@@ -124,7 +124,6 @@ class H2Protocol(asyncio.Protocol):
         method = request_data.headers[':method']
         if method == "PUT" or method == "POST":
             self.conn.send_headers(stream_id, [(':status', '200')])
-            print(self.num_sentence_received)
             asyncio.ensure_future(self.send_data(
                 str(self.num_sentence_received).encode(), stream_id))
         elif path == '/echo':
@@ -155,8 +154,10 @@ class H2Protocol(asyncio.Protocol):
                 self.num_sentence_received = self.num_sentence_received + \
                     len(data)
                 # update window for stream
-                self.conn.increment_flow_control_window(len(data))
-                self.conn.increment_flow_control_window(len(data), stream_id)
+                if len(data) > 0:
+                    self.conn.increment_flow_control_window(len(data))
+                    self.conn.increment_flow_control_window(
+                        len(data), stream_id)
             else:
                 stream_data.data.write(data)
 

--- a/tests/py_localhost/server.py
+++ b/tests/py_localhost/server.py
@@ -156,7 +156,6 @@ class H2Protocol(asyncio.Protocol):
                         len(data)
                 else:
                     self.num_sentence_received[stream_id] = len(data)
-                print(self.num_sentence_received[stream_id])
                 # update window for stream
                 if len(data) > 0:
                     self.conn.increment_flow_control_window(len(data))

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -254,7 +254,8 @@ static int s_tester_init(struct tester *tester, struct aws_allocator *allocator,
     };
     ASSERT_SUCCESS(aws_http_client_connect(&client_options));
     struct aws_logger_standard_options logger_options = {
-        .level = AWS_LOG_LEVEL_DEBUG,
+        .level = AWS_LOG_LEVEL_DEBUG, /* We are stress testing, and if this ever failed, the default trace level log is
+                                         too much to handle, let's do debug level instead */
         .file = stderr,
     };
 

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -383,15 +383,19 @@ static int s_tester_on_put_body(struct aws_http_stream *stream, const struct aws
     return AWS_OP_SUCCESS;
 }
 
-/* Test that upload a 0.25GB data to local server */
+/* Test that upload a 2.5GB data to local server */
 AWS_TEST_CASE(localhost_integ_h2_upload_stress, s_localhost_integ_h2_upload_stress)
 static int s_localhost_integ_h2_upload_stress(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     s_tester.alloc = allocator;
+
+    size_t length = 2500000000UL;
+#ifdef AWS_OS_LINUX
     /* Using Python hyper h2 server frame work, met a weird upload performance issue on Linux. Our client against nginx
-     * platform has not met the same issue. We assume it's because the server framework implementation. Test 0.25GB now
-     */
-    size_t length = 250000000UL;
+     * platform has not met the same issue. We assume it's because the server framework implementation.  Use lower
+     * number of linux */
+    length = 250000000UL;
+#endif
 
     struct aws_string *http_localhost_host = NULL;
     if (aws_get_environment_value(allocator, s_http_localhost_env_var, &http_localhost_host) ||

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -85,7 +85,7 @@ struct tester {
     size_t stream_4xx_count;
     size_t stream_status_not_200_count;
 
-    size_t num_sen_received;
+    uint64_t num_sen_received;
     int stream_completed_error_code;
     bool stream_completed_with_200;
 
@@ -387,7 +387,7 @@ static int s_tester_on_put_body(struct aws_http_stream *stream, const struct aws
     (void)stream;
     (void)user_data;
     struct aws_string *content_length_header_str = aws_string_new_from_cursor(s_tester.alloc, data);
-    s_tester.num_sen_received = (uint32_t)atoi((const char *)content_length_header_str->bytes);
+    s_tester.num_sen_received = (uint64_t)strtoull((const char *)content_length_header_str->bytes, NULL, 10);
     aws_string_destroy(content_length_header_str);
 
     return AWS_OP_SUCCESS;

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -420,7 +420,6 @@ static int s_localhost_integ_h2_upload_stress(struct aws_allocator *allocator, v
         },
     };
     struct aws_http_message *request = aws_http2_message_new_request(allocator);
-    ASSERT_NOT_NULL(request);
     aws_http_message_add_header_array(request, request_headers_src, AWS_ARRAY_SIZE(request_headers_src));
     struct aws_input_stream *body_stream = aws_input_stream_tester_upload_new(allocator, length);
     aws_http_message_set_body_stream(request, body_stream);

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -202,6 +202,8 @@ static void s_tester_on_stream_completed(struct aws_http_stream *stream, int err
     AWS_FATAL_ASSERT(aws_mutex_unlock(&s_tester.wait_lock) == AWS_OP_SUCCESS);
 }
 
+static struct aws_logger s_logger;
+
 static int s_tester_init(struct tester *tester, struct aws_allocator *allocator, struct aws_byte_cursor host_name) {
     aws_http_library_init(allocator);
 
@@ -251,6 +253,13 @@ static int s_tester_init(struct tester *tester, struct aws_allocator *allocator,
         .on_shutdown = s_on_connection_shutdown,
     };
     ASSERT_SUCCESS(aws_http_client_connect(&client_options));
+    struct aws_logger_standard_options logger_options = {
+        .level = AWS_LOG_LEVEL_DEBUG,
+        .file = stderr,
+    };
+
+    aws_logger_init_standard(&s_logger, allocator, &logger_options);
+    aws_logger_set(&s_logger);
     return AWS_OP_SUCCESS;
 }
 
@@ -267,6 +276,7 @@ static int s_tester_clean_up(struct tester *tester) {
 
     aws_mutex_clean_up(&tester->wait_lock);
     aws_http_library_clean_up();
+    aws_logger_clean_up(&s_logger);
     return AWS_OP_SUCCESS;
 }
 

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -484,7 +484,6 @@ static void s_sm_tester_on_stream_complete(struct aws_http_stream *stream, int e
 
 static int s_sm_stream_acquiring_customize_request(
     int num_streams,
-    struct aws_http_message *request,
     struct aws_http_make_request_options *request_options) {
     struct aws_http2_stream_manager_acquire_stream_options acquire_stream_option = {
         .options = request_options,
@@ -1284,6 +1283,14 @@ TEST_CASE(localhost_integ_h2_sm_acquire_stream_stress_with_body) {
     };
     ASSERT_SUCCESS(s_tester_init(&options));
     int num_to_acquire = 500 * 100;
+
+#ifdef AWS_OS_LINUX
+    /* Using Python hyper h2 server frame work, met a weird upload performance issue on Linux. Our client against nginx
+     * platform has not met the same issue. We assume it's because the server framework implementation. Use lower
+     * number of linux
+     */
+    num_to_acquire = 500;
+#endif
 
     ASSERT_SUCCESS(s_sm_stream_acquiring_with_body(num_to_acquire));
     ASSERT_SUCCESS(s_wait_on_streams_completed_count(num_to_acquire));

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -524,7 +524,7 @@ static int s_sm_stream_acquiring(int num_streams) {
         .user_data = &s_tester,
         .on_complete = s_sm_tester_on_stream_complete,
     };
-    int return_code = s_sm_stream_acquiring_customize_request(num_streams, request, &request_options);
+    int return_code = s_sm_stream_acquiring_customize_request(num_streams, &request_options);
     aws_http_message_release(request);
     return return_code;
 }

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -481,6 +481,23 @@ static void s_sm_tester_on_stream_complete(struct aws_http_stream *stream, int e
     AWS_FATAL_ASSERT(aws_mutex_unlock(&s_tester.lock) == AWS_OP_SUCCESS);
 }
 
+static int s_sm_stream_acquiring_customize_request(
+    int num_streams,
+    struct aws_http_message *request,
+    struct aws_http_make_request_options *request_options) {
+    struct aws_http2_stream_manager_acquire_stream_options acquire_stream_option = {
+        .options = request_options,
+        .callback = s_sm_tester_on_stream_acquired,
+        .user_data = &s_tester,
+    };
+    for (int i = 0; i < num_streams; ++i) {
+        /* TODO: Test the callback will always be fired asynced, as now the CM cannot ensure the callback happens
+         * asynchronously, we cannot ensure it as well. */
+        aws_http2_stream_manager_acquire_stream(s_tester.stream_manager, &acquire_stream_option);
+    }
+    return AWS_OP_SUCCESS;
+}
+
 static int s_sm_stream_acquiring(int num_streams) {
     struct aws_http_message *request = aws_http2_message_new_request(s_tester.allocator);
     ASSERT_NOT_NULL(request);
@@ -507,18 +524,9 @@ static int s_sm_stream_acquiring(int num_streams) {
         .user_data = &s_tester,
         .on_complete = s_sm_tester_on_stream_complete,
     };
-    struct aws_http2_stream_manager_acquire_stream_options acquire_stream_option = {
-        .options = &request_options,
-        .callback = s_sm_tester_on_stream_acquired,
-        .user_data = &s_tester,
-    };
-    for (int i = 0; i < num_streams; ++i) {
-        /* TODO: Test the callback will always be fired asynced, as now the CM cannot ensure the callback happens
-         * asynchronously, we cannot ensure it as well. */
-        aws_http2_stream_manager_acquire_stream(s_tester.stream_manager, &acquire_stream_option);
-    }
+    int return_code = s_sm_stream_acquiring_customize_request(num_streams, request, &request_options);
     aws_http_message_release(request);
-    return AWS_OP_SUCCESS;
+    return return_code;
 }
 
 /* Test the common setup/teardown used by all tests in this file */
@@ -1191,11 +1199,79 @@ TEST_CASE(localhost_integ_h2_sm_acquire_stream_stress) {
         .uri_cursor = &uri_cursor,
     };
     ASSERT_SUCCESS(s_tester_init(&options));
-    int num_to_acquire = 200 * 100;
+    int num_to_acquire = 500 * 100;
     ASSERT_SUCCESS(s_sm_stream_acquiring(num_to_acquire));
     ASSERT_SUCCESS(s_wait_on_streams_completed_count(num_to_acquire));
     ASSERT_TRUE((int)s_tester.acquiring_stream_errors == 0);
     ASSERT_TRUE((int)s_tester.stream_200_count == num_to_acquire);
 
+    return s_tester_clean_up();
+}
+
+static int s_tester_on_put_body(struct aws_http_stream *stream, const struct aws_byte_cursor *data, void *user_data) {
+
+    (void)stream;
+    size_t length = (size_t)user_data;
+    struct aws_string *content_length_header_str = aws_string_new_from_cursor(s_tester.allocator, data);
+    size_t num_received = (uint32_t)atoi((const char *)content_length_header_str->bytes);
+    AWS_FATAL_ASSERT(length == num_received);
+    aws_string_destroy(content_length_header_str);
+
+    return AWS_OP_SUCCESS;
+}
+
+/* Test that makes tons of real streams with body against local host */
+TEST_CASE(localhost_integ_h2_sm_acquire_stream_stress_with_body) {
+    (void)ctx;
+    struct aws_byte_cursor uri_cursor = aws_byte_cursor_from_c_str("https://localhost:8443/upload_test");
+    struct sm_tester_options options = {
+        .max_connections = 100,
+        .max_concurrent_streams_per_connection = 100,
+        .alloc = allocator,
+        .uri_cursor = &uri_cursor,
+    };
+    ASSERT_SUCCESS(s_tester_init(&options));
+    int num_to_acquire = 500 * 100;
+    char content_length_sprintf_buffer[128] = "";
+    size_t length = 2000;
+    snprintf(content_length_sprintf_buffer, sizeof(content_length_sprintf_buffer), "%zu", length);
+
+    struct aws_http_header request_headers_src[] = {
+        DEFINE_HEADER(":method", "PUT"),
+        {
+            .name = aws_byte_cursor_from_c_str(":scheme"),
+            .value = *aws_uri_scheme(&s_tester.endpoint),
+        },
+        {
+            .name = aws_byte_cursor_from_c_str(":path"),
+            .value = *aws_uri_path(&s_tester.endpoint),
+        },
+        {
+            .name = aws_byte_cursor_from_c_str(":authority"),
+            .value = *aws_uri_host_name(&s_tester.endpoint),
+        },
+        {
+            .name = aws_byte_cursor_from_c_str("content_length"),
+            .value = aws_byte_cursor_from_c_str(content_length_sprintf_buffer),
+        },
+    };
+    struct aws_http_message *request = aws_http2_message_new_request(allocator);
+    aws_http_message_add_header_array(request, request_headers_src, AWS_ARRAY_SIZE(request_headers_src));
+    struct aws_input_stream *body_stream = aws_input_stream_tester_upload_new(allocator, length);
+    aws_http_message_set_body_stream(request, body_stream);
+    aws_input_stream_release(body_stream);
+    struct aws_http_make_request_options request_options = {
+        .self_size = sizeof(request_options),
+        .request = request,
+        .user_data = &length,
+        .on_complete = s_sm_tester_on_stream_complete,
+    };
+
+    ASSERT_SUCCESS(s_sm_stream_acquiring_customize_request(num_to_acquire, request, &request_options));
+    ASSERT_SUCCESS(s_wait_on_streams_completed_count(num_to_acquire));
+    ASSERT_TRUE((int)s_tester.acquiring_stream_errors == 0);
+    ASSERT_TRUE((int)s_tester.stream_200_count == num_to_acquire);
+
+    aws_http_message_release(request);
     return s_tester_clean_up();
 }

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -18,6 +18,7 @@
 #include <aws/http/private/proxy_impl.h>
 #include <aws/http/proxy.h>
 
+#include <aws/io/stream.h>
 #include <aws/io/uri.h>
 
 #include <aws/common/byte_buf.h>
@@ -1211,7 +1212,7 @@ TEST_CASE(localhost_integ_h2_sm_acquire_stream_stress) {
 static int s_tester_on_put_body(struct aws_http_stream *stream, const struct aws_byte_cursor *data, void *user_data) {
 
     (void)stream;
-    size_t length = (size_t)user_data;
+    size_t length = *(size_t *)user_data;
     struct aws_string *content_length_header_str = aws_string_new_from_cursor(s_tester.allocator, data);
     size_t num_received = (uint32_t)atoi((const char *)content_length_header_str->bytes);
     AWS_FATAL_ASSERT(length == num_received);
@@ -1264,6 +1265,7 @@ TEST_CASE(localhost_integ_h2_sm_acquire_stream_stress_with_body) {
         .self_size = sizeof(request_options),
         .request = request,
         .user_data = &length,
+        .on_response_body = s_tester_on_put_body,
         .on_complete = s_sm_tester_on_stream_complete,
     };
 

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -1211,10 +1211,10 @@ TEST_CASE(localhost_integ_h2_sm_acquire_stream_stress) {
 static int s_tester_on_put_body(struct aws_http_stream *stream, const struct aws_byte_cursor *data, void *user_data) {
 
     (void)stream;
-    size_t length = *(size_t *)user_data;
+    size_t *length = (size_t *)user_data;
     struct aws_string *content_length_header_str = aws_string_new_from_cursor(s_tester.allocator, data);
     size_t num_received = (uint32_t)atoi((const char *)content_length_header_str->bytes);
-    AWS_FATAL_ASSERT(length == num_received);
+    AWS_FATAL_ASSERT(*length == num_received);
     aws_string_destroy(content_length_header_str);
 
     return AWS_OP_SUCCESS;


### PR DESCRIPTION
- Add parallel stress test with body sent
- Updated server implementation to handle multiple streams with body.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
