### PR TITLE
Use const for aws_http_connection_manager_options

### DIFF
--- a/include/aws/http/connection_manager.h
+++ b/include/aws/http/connection_manager.h
@@ -152,7 +152,7 @@ void aws_http_connection_manager_release(struct aws_http_connection_manager *man
 AWS_HTTP_API
 struct aws_http_connection_manager *aws_http_connection_manager_new(
     struct aws_allocator *allocator,
-    struct aws_http_connection_manager_options *options);
+    const struct aws_http_connection_manager_options *options);
 
 /*
  * Requests a connection from the manager.  The requester is notified of

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -790,7 +790,7 @@ static void s_schedule_connection_culling(struct aws_http_connection_manager *ma
 
 struct aws_http_connection_manager *aws_http_connection_manager_new(
     struct aws_allocator *allocator,
-    struct aws_http_connection_manager_options *options) {
+    const struct aws_http_connection_manager_options *options) {
 
     aws_http_fatal_assert_library_initialized();
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
