### PR TITLE
sprintf() -> snprintf()

### DIFF
--- a/bin/elasticurl/main.c
+++ b/bin/elasticurl/main.c
@@ -442,7 +442,7 @@ static struct aws_http_message *s_build_http_request(
         if (data_len > 0) {
             char content_length[64];
             AWS_ZERO_ARRAY(content_length);
-            sprintf(content_length, "%" PRIi64, data_len);
+            snprintf(content_length, sizeof(content_length), "%" PRIi64, data_len);
             struct aws_http_header content_length_header = {
                 .name = aws_byte_cursor_from_c_str("content-length"),
                 .value = aws_byte_cursor_from_c_str(content_length),

--- a/tests/test_connection_monitor.c
+++ b/tests/test_connection_monitor.c
@@ -16,10 +16,6 @@
 #include <aws/testing/aws_test_harness.h>
 #include <aws/testing/io_testing_channel.h>
 
-#ifdef _MSC_VER
-#    pragma warning(disable : 4996) /* Disable warnings about sprintf() being insecure */
-#endif
-
 static int s_test_http_connection_monitor_options_is_valid(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)allocator;
@@ -1115,7 +1111,7 @@ static void s_add_outgoing_stream(struct test_http_stats_event *event) {
     AWS_FATAL_ASSERT(event->request_body_size <= MAX_BODY_SIZE);
     if (event->request_body_size > 0) {
         char cl_buffer[256];
-        sprintf(cl_buffer, "%zu", event->request_body_size);
+        snprintf(cl_buffer, sizeof(cl_buffer), "%zu", event->request_body_size);
 
         struct aws_http_header content_length_header = {
             .name = aws_byte_cursor_from_c_str("content-length"),

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -22,10 +22,6 @@
 
 #include "h2_test_helper.h"
 
-#ifdef _MSC_VER
-#    pragma warning(disable : 4996) /* Disable warnings about sprintf() being insecure */
-#endif
-
 static int s_tester_on_headers(
     struct aws_http_stream *stream,
     enum aws_http_header_block header_block,
@@ -332,10 +328,10 @@ static int s_test_hpack_stress_helper(struct aws_allocator *allocator, bool comp
             aws_device_random_u64(&random_64_bit_num);
 
             size_t headers = (size_t)random_64_bit_num % headers_pool_size;
-            sprintf(test_header_str, "crttest-%zu", headers);
+            snprintf(test_header_str, sizeof(test_header_str), "crttest-%zu", headers);
             char test_value_str[256];
             size_t value = (size_t)random_64_bit_num % values_pool_size;
-            sprintf(test_value_str, "value-%zu", value);
+            snprintf(test_value_str, sizeof(test_value_str), "value-%zu", value);
 
             struct aws_http_header request_header = {
                 .compression =


### PR DESCRIPTION
Issue: Today my Mac started issuing warnings about sprintf().
Changes: Use snprintf() instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
