### PR TITLE
WebSocket ref-counts its HTTP request

### DIFF
--- a/include/aws/http/connection.h
+++ b/include/aws/http/connection.h
@@ -256,7 +256,7 @@ struct aws_http_client_connection_options {
 
     /**
      * Required.
-     * Must outlive the connection.
+     * The connection keeps the bootstrap alive via ref-counting.
      */
     struct aws_client_bootstrap *bootstrap;
 
@@ -279,8 +279,8 @@ struct aws_http_client_connection_options {
 
     /**
      * Optional.
-     * aws_http_client_connect() deep-copies all contents except the `aws_tls_ctx`,
-     * which must outlive the the connection.
+     * aws_http_client_connect() deep-copies all contents,
+     * and keeps `aws_tls_ctx` alive via ref-counting.
      */
     const struct aws_tls_connection_options *tls_options;
 

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -207,7 +207,7 @@ struct aws_http_make_request_options {
     /**
      * Definition for outgoing request.
      * Required.
-     * This object must stay alive at least until on_complete is called.
+     * The request will be kept alive via refcounting until the request completes.
      */
     struct aws_http_message *request;
 

--- a/include/aws/http/websocket.h
+++ b/include/aws/http/websocket.h
@@ -132,7 +132,7 @@ struct aws_websocket_client_connection_options {
 
     /**
      * Required.
-     * Must outlive the connection.
+     * The connection keeps the bootstrap alive via ref-counting.
      */
     struct aws_client_bootstrap *bootstrap;
 
@@ -144,8 +144,8 @@ struct aws_websocket_client_connection_options {
 
     /**
      * Optional.
-     * aws_websocket_client_connect() deep-copies all contents except the `aws_tls_ctx`,
-     * which must outlive the the connection.
+     * aws_websocket_client_connect() deep-copies all contents,
+     * and keeps the `aws_tls_ctx` alive via ref-counting.
      */
     const struct aws_tls_connection_options *tls_options;
 
@@ -169,7 +169,7 @@ struct aws_websocket_client_connection_options {
 
     /**
      * Required.
-     * The request will be kept alive via refcounting until the handshake completes.
+     * The request will be kept alive via ref-counting until the handshake completes.
      * Suggestion: create via aws_http_message_new_websocket_handshake_request()
      *
      * The method MUST be set to GET.

--- a/include/aws/http/websocket.h
+++ b/include/aws/http/websocket.h
@@ -169,7 +169,7 @@ struct aws_websocket_client_connection_options {
 
     /**
      * Required.
-     * The request must outlive the handshake process (it will be safe to release in on_connection_setup())
+     * The request will be kept alive via refcounting until the handshake completes.
      * Suggestion: create via aws_http_message_new_websocket_handshake_request()
      *
      * The method MUST be set to GET.

--- a/source/websocket_bootstrap.c
+++ b/source/websocket_bootstrap.c
@@ -155,7 +155,7 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     ws_bootstrap->websocket_frame_begin_callback = options->on_incoming_frame_begin;
     ws_bootstrap->websocket_frame_payload_callback = options->on_incoming_frame_payload;
     ws_bootstrap->websocket_frame_complete_callback = options->on_incoming_frame_complete;
-    ws_bootstrap->handshake_request = options->handshake_request;
+    ws_bootstrap->handshake_request = aws_http_message_acquire(options->handshake_request);
     ws_bootstrap->response_status = AWS_HTTP_STATUS_CODE_UNKNOWN;
 
     /* Pre-allocate space for response headers */
@@ -242,6 +242,7 @@ static void s_ws_bootstrap_destroy(struct aws_websocket_client_bootstrap *ws_boo
         return;
     }
 
+    aws_http_message_release(ws_bootstrap->handshake_request);
     aws_array_list_clean_up(&ws_bootstrap->response_headers);
     aws_byte_buf_clean_up(&ws_bootstrap->response_storage);
 


### PR DESCRIPTION
The WebSocket wasn't using acquire()/release() ref-counting on its HTTP request, because this code was written before we realized ref-counting was a thing we needed to do.

Also, correct a bunch of comments about old-fashioned lifetime management that don't apply now that we ref-count everything.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
