### PR TITLE
Stop hitting example.com in tests

### DIFF
--- a/integration-testing/http_client_test.py
+++ b/integration-testing/http_client_test.py
@@ -82,7 +82,7 @@ class SimpleTests(unittest.TestCase):
         run_command(simple_get_args)
     def test_simple_get_h1(self):
         """make a simple GET request via HTTP/1.1 and make sure it succeeds"""
-        simple_get_args = elasticurl_cmd_prefix + ['-v', 'TRACE', '--http1_1', 'http://example.com']
+        simple_get_args = elasticurl_cmd_prefix + ['-v', 'TRACE', '--http1_1', 'http://httpbin.org/get']
         run_command(simple_get_args)
 
     def test_simple_post_h1(self):
@@ -100,7 +100,7 @@ class SimpleTests(unittest.TestCase):
 
     def test_simple_get_h2(self):
         """make a simple GET request via HTTP2 and make sure it succeeds"""
-        simple_get_args = elasticurl_cmd_prefix + ['-v', 'TRACE', '--http2', 'https://example.com']
+        simple_get_args = elasticurl_cmd_prefix + ['-v', 'TRACE', '--http2', 'https://httpbin.org/get']
         run_command(simple_get_args)
 
     def test_simple_post_h2(self):


### PR DESCRIPTION
it's timing out too often

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
