### PR TITLE
Add ProxyConfig new from ProxyOptions & TLS info

### DIFF
--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -507,18 +507,16 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
     const struct aws_http_proxy_options *options);
 
 /**
- * Create a persistent proxy configuration from non-persistent proxy options.
+ * @brief Determine proxy_connection_type based on tls_options configuration if connection_type is legacy.
  *
- * @param allocator memory allocator to use
- * @param options http proxy options to source proxy configuration from
- * @param tls_connection_options tls connection options to determine connection_type if connection type is legacy
- * @return
+ * @param proxy_connection_type
+ * @param tls_options
+ * @return AWS_HTTP_API enum
  */
 AWS_HTTP_API
-struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_tls_options(
-    struct aws_allocator *allocator,
-    const struct aws_http_proxy_options *proxy_options,
-    const struct aws_tls_connection_options *tls_connection_options);
+enum aws_http_proxy_connection_type s_determine_proxy_connection_type(
+    enum aws_http_proxy_connection_type proxy_connection_type,
+    bool tls_options);
 
 /**
  * Clones an existing proxy configuration.  A refactor could remove this (do a "move" between the old and new user
@@ -529,8 +527,7 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_
  * @param proxy_config http proxy configuration to clone
  * @return
  */
-AWS_HTTP_API
-struct aws_http_proxy_config *aws_http_proxy_config_new_clone(
+AWS_HTTP_API struct aws_http_proxy_config *aws_http_proxy_config_new_clone(
     struct aws_allocator *allocator,
     const struct aws_http_proxy_config *proxy_config);
 

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -511,7 +511,7 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
  *
  * @param allocator memory allocator to use
  * @param options http proxy options to source proxy configuration from
- * @param is_tls_connection tls connection info to determine connection_type if connection type is legacy
+ * @param is_tls_connection tls connection info of the main connection to determine connection_type if connection type is legacy
  * @return
  */
 AWS_HTTP_API

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -507,6 +507,20 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
     const struct aws_http_proxy_options *options);
 
 /**
+ * Create a persistent proxy configuration from non-persistent proxy options.
+ *
+ * @param allocator memory allocator to use
+ * @param options http proxy options to source proxy configuration from
+ * @param tls_connection_options tls connection options to determine connection_type if connection type is legacy
+ * @return
+ */
+AWS_HTTP_API
+struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_tls_options(
+    struct aws_allocator *allocator,
+    const struct aws_http_proxy_options *proxy_options,
+    const struct aws_tls_connection_options *tls_connection_options);
+
+/**
  * Clones an existing proxy configuration.  A refactor could remove this (do a "move" between the old and new user
  * data in the one spot it's used) but that should wait until we have better test cases for the logic where this
  * gets invoked (ntlm/kerberos chains).

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -511,8 +511,8 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
  *
  * @param allocator memory allocator to use
  * @param options http proxy options to source proxy configuration from
- * @param is_tls_connection tls connection info of the main connection to determine connection_type 
- *                          when the connection_type is legacy. 
+ * @param is_tls_connection tls connection info of the main connection to determine connection_type
+ *                          when the connection_type is legacy.
  * @return
  */
 AWS_HTTP_API

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -511,7 +511,8 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
  *
  * @param allocator memory allocator to use
  * @param options http proxy options to source proxy configuration from
- * @param is_tls_connection tls connection info of the main connection to determine connection_type if connection type is legacy
+ * @param is_tls_connection tls connection info of the main connection to determine connection_type 
+ *                          when the connection_type is legacy. 
  * @return
  */
 AWS_HTTP_API

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -507,16 +507,18 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
     const struct aws_http_proxy_options *options);
 
 /**
- * @brief Determine proxy_connection_type based on tls_options configuration if connection_type is legacy.
+ * Create a persistent proxy configuration from non-persistent proxy options.
  *
- * @param proxy_connection_type
- * @param tls_options
- * @return AWS_HTTP_API enum
+ * @param allocator memory allocator to use
+ * @param options http proxy options to source proxy configuration from
+ * @param is_tls_connection tls connection info to determine connection_type if connection type is legacy
+ * @return
  */
 AWS_HTTP_API
-enum aws_http_proxy_connection_type s_determine_proxy_connection_type(
-    enum aws_http_proxy_connection_type proxy_connection_type,
-    bool tls_options);
+struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_tls_info(
+    struct aws_allocator *allocator,
+    const struct aws_http_proxy_options *proxy_options,
+    bool *is_tls_connection);
 
 /**
  * Clones an existing proxy configuration.  A refactor could remove this (do a "move" between the old and new user

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -518,7 +518,7 @@ AWS_HTTP_API
 struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_tls_info(
     struct aws_allocator *allocator,
     const struct aws_http_proxy_options *proxy_options,
-    bool *is_tls_connection);
+    bool is_tls_connection);
 
 /**
  * Clones an existing proxy configuration.  A refactor could remove this (do a "move" between the old and new user
@@ -529,7 +529,8 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_
  * @param proxy_config http proxy configuration to clone
  * @return
  */
-AWS_HTTP_API struct aws_http_proxy_config *aws_http_proxy_config_new_clone(
+AWS_HTTP_API
+struct aws_http_proxy_config *aws_http_proxy_config_new_clone(
     struct aws_allocator *allocator,
     const struct aws_http_proxy_config *proxy_config);
 

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -1426,7 +1426,6 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_
     const struct aws_http_proxy_options *proxy_options,
     const struct aws_tls_connection_options *tls_connection_options) {
     AWS_FATAL_ASSERT(proxy_options != NULL);
-    AWS_FATAL_ASSERT(tls_connection_options != NULL);
 
     return s_aws_http_proxy_config_new(
         allocator,

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -1421,6 +1421,19 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_tunneling_from_proxy_opt
     return s_aws_http_proxy_config_new(allocator, proxy_options, AWS_HPCT_HTTP_TUNNEL);
 }
 
+struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_tls_options(
+    struct aws_allocator *allocator,
+    const struct aws_http_proxy_options *proxy_options,
+    const struct aws_tls_connection_options *tls_connection_options) {
+    AWS_FATAL_ASSERT(proxy_options != NULL);
+    AWS_FATAL_ASSERT(tls_connection_options != NULL);
+
+    return s_aws_http_proxy_config_new(
+        allocator,
+        proxy_options,
+        s_determine_proxy_connection_type(proxy_options->connection_type, tls_connection_options));
+}
+
 struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
     struct aws_allocator *allocator,
     const struct aws_http_proxy_options *proxy_options) {

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -1123,14 +1123,14 @@ static int s_aws_http_client_connect_via_tunneling_proxy(
     return s_create_tunneling_connection(user_data);
 }
 
-enum aws_http_proxy_connection_type s_determine_proxy_connection_type(
+static enum aws_http_proxy_connection_type s_determine_proxy_connection_type(
     enum aws_http_proxy_connection_type proxy_connection_type,
-    bool tls_options) {
+    bool is_tls_connection) {
     if (proxy_connection_type != AWS_HPCT_HTTP_LEGACY) {
         return proxy_connection_type;
     }
 
-    if (tls_options) {
+    if (is_tls_connection) {
         return AWS_HPCT_HTTP_TUNNEL;
     } else {
         return AWS_HPCT_HTTP_FORWARD;
@@ -1431,6 +1431,16 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options(
     }
 
     return s_aws_http_proxy_config_new(allocator, proxy_options, proxy_options->connection_type);
+}
+
+struct aws_http_proxy_config *aws_http_proxy_config_new_from_proxy_options_with_tls_info(
+    struct aws_allocator *allocator,
+    const struct aws_http_proxy_options *proxy_options,
+    bool is_tls_connection) {
+    AWS_FATAL_ASSERT(proxy_options != NULL);
+
+    return s_aws_http_proxy_config_new(
+        allocator, proxy_options, s_determine_proxy_connection_type(proxy_options->connection_type, is_tls_connection));
 }
 
 struct aws_http_proxy_config *aws_http_proxy_config_new_clone(


### PR DESCRIPTION
*Description of changes:*
- Adds a new function proxy_config new from proxy_options & tls which will be used by `s3_client_new` to make a copy of proxy options.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
