### PR TITLE
Fix warnings in public headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.40
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: header-warnings
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: header-warnings
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.43
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -10,7 +10,8 @@ phases:
   pre_build:
     commands:
       - export CC=gcc-7
-      - export BUILDER_VERSION=v0.9.29
+      - export BUILDER_VERSION=$(cat .github/workflows/ci.yml | grep 'BUILDER_VERSION:' | sed 's/\s*BUILDER_VERSION:\s*\(.*\)/\1/')
+      - echo "Using builder version ${BUILDER_VERSION}"
       - export BUILDER_SOURCE=releases
       - export BUILDER_HOST=https://d19elf31gohf1l.cloudfront.net
   build:

--- a/include/aws/http/connection.h
+++ b/include/aws/http/connection.h
@@ -8,6 +8,8 @@
 
 #include <aws/http/http.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_client_bootstrap;
 struct aws_socket_options;
 struct aws_socket_endpoint;
@@ -688,5 +690,6 @@ AWS_HTTP_API
 void aws_http2_connection_update_window(struct aws_http_connection *http2_connection, uint32_t increment_size);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_CONNECTION_H */

--- a/include/aws/http/connection_manager.h
+++ b/include/aws/http/connection_manager.h
@@ -10,6 +10,8 @@
 
 #include <aws/common/byte_buf.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_client_bootstrap;
 struct aws_http_connection;
 struct aws_http_connection_manager;
@@ -190,5 +192,6 @@ void aws_http_connection_manager_fetch_metrics(
     struct aws_http_manager_metrics *out_metrics);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_CONNECTION_MANAGER_H */

--- a/include/aws/http/http.h
+++ b/include/aws/http/http.h
@@ -10,6 +10,8 @@
 #include <aws/http/exports.h>
 #include <aws/io/io.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 #define AWS_C_HTTP_PACKAGE_ID 2
 
 enum aws_http_errors {
@@ -154,5 +156,6 @@ AWS_HTTP_API extern const struct aws_byte_cursor aws_http_scheme_http;
 AWS_HTTP_API extern const struct aws_byte_cursor aws_http_scheme_https;
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_H */

--- a/include/aws/http/http2_stream_manager.h
+++ b/include/aws/http/http2_stream_manager.h
@@ -8,6 +8,8 @@
 
 #include <aws/http/http.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_http2_stream_manager;
 struct aws_client_bootstrap;
 struct aws_http_connection;
@@ -212,4 +214,6 @@ void aws_http2_stream_manager_fetch_metrics(
     struct aws_http_manager_metrics *out_metrics);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
+
 #endif /* AWS_HTTP2_STREAM_MANAGER_H */

--- a/include/aws/http/proxy.h
+++ b/include/aws/http/proxy.h
@@ -11,6 +11,8 @@
 #include <aws/http/request_response.h>
 #include <aws/http/status_code.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_http_client_connection_options;
 struct aws_http_connection_manager_options;
 
@@ -566,5 +568,6 @@ AWS_HTTP_API int aws_http_proxy_new_socket_channel(
     const struct aws_http_proxy_options *proxy_options);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_PROXY_STRATEGY_H */

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -8,6 +8,8 @@
 
 #include <aws/http/http.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_http_connection;
 struct aws_input_stream;
 
@@ -1121,5 +1123,6 @@ AWS_HTTP_API
 int aws_http2_stream_get_sent_reset_error_code(struct aws_http_stream *http2_stream, uint32_t *out_http2_error);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_REQUEST_RESPONSE_H */

--- a/include/aws/http/server.h
+++ b/include/aws/http/server.h
@@ -8,6 +8,8 @@
 
 #include <aws/http/http.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_http_connection;
 struct aws_server_bootstrap;
 struct aws_socket_options;
@@ -194,5 +196,6 @@ AWS_HTTP_API
 bool aws_http_connection_is_server(const struct aws_http_connection *connection);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_SERVER_H */

--- a/include/aws/http/statistics.h
+++ b/include/aws/http/statistics.h
@@ -10,6 +10,8 @@
 
 #include <aws/common/statistics.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 enum aws_crt_http_statistics_category {
     AWSCRT_STAT_CAT_HTTP1_CHANNEL = AWS_CRT_STATISTICS_CATEGORY_BEGIN_RANGE(AWS_C_HTTP_PACKAGE_ID),
     AWSCRT_STAT_CAT_HTTP2_CHANNEL,
@@ -71,5 +73,6 @@ AWS_HTTP_API
 void aws_crt_statistics_http2_channel_reset(struct aws_crt_statistics_http2_channel *stats);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_STATISTICS_H */

--- a/include/aws/http/websocket.h
+++ b/include/aws/http/websocket.h
@@ -7,6 +7,8 @@
 
 #include <aws/http/http.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_http_header;
 struct aws_http_message;
 
@@ -485,5 +487,6 @@ struct aws_http_message *aws_http_message_new_websocket_handshake_request(
     struct aws_byte_cursor host);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_HTTP_WEBSOCKET_H */


### PR DESCRIPTION
*Description of changes:*
- Adds `AWS_PUSH_SANE_WARNING_LEVEL` and `AWS_POP_SANE_WARNING_LEVEL` to the public headers. The public header should contain at least one include; otherwise, we will receive a macro not found error. Therefore, I decided to skip adding these macros if there are no includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.