### PR TITLE
aws_future<aws_http_message *>

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.43
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: head-detached-bug
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -11,8 +11,8 @@ phases:
     commands:
       - export CC=gcc-7
       - export BUILDER_VERSION=$(cat .github/workflows/ci.yml | grep 'BUILDER_VERSION:' | sed 's/\s*BUILDER_VERSION:\s*\(.*\)/\1/')
-      - echo "Using builder version ${BUILDER_VERSION}"
-      - export BUILDER_SOURCE=releases
+      - export BUILDER_SOURCE=$(cat .github/workflows/ci.yml | grep 'BUILDER_SOURCE:' | sed 's/\s*BUILDER_SOURCE:\s*\(.*\)/\1/')
+      - echo "Using builder version='${BUILDER_VERSION}' source='${BUILDER_SOURCE}'"
       - export BUILDER_HOST=https://d19elf31gohf1l.cloudfront.net
   build:
     commands:

--- a/include/aws/http/request_response.h
+++ b/include/aws/http/request_response.h
@@ -8,6 +8,8 @@
 
 #include <aws/http/http.h>
 
+#include <aws/io/future.h>
+
 AWS_PUSH_SANE_WARNING_LEVEL
 
 struct aws_http_connection;
@@ -854,6 +856,11 @@ struct aws_input_stream *aws_http_message_get_body_stream(const struct aws_http_
  */
 AWS_HTTP_API
 void aws_http_message_set_body_stream(struct aws_http_message *message, struct aws_input_stream *body_stream);
+
+/**
+ * aws_future<aws_http_message*>
+ */
+AWS_DECLARE_FUTURE_T_POINTER_WITH_RELEASE(aws_future_http_message, struct aws_http_message, aws_http_message_release)
 
 /**
  * Submit a chunk of data to be sent on an HTTP/1.1 stream.


### PR DESCRIPTION
Declare `aws_future_http_message`. This will be used by [aws-c-s3](https://github.com/awslabs/aws-c-s3/blob/5849ecfd63d07a37772b9f39194c3b0b49087a6f/source/s3_auto_ranged_put.c#L42)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
