### PR TITLE
use latest aws-crt-builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: head-detached-bug
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.46
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http
   LINUX_BASE_IMAGE: ubuntu-18-x64


### PR DESCRIPTION
I accidentally changed ci.yml to use "channels"  instead of an official release in my last PR https://github.com/awslabs/aws-c-http/pull/443


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
