### PR TITLE
Explicit Private for target_link_libraries

### DIFF
--- a/bin/elasticurl/CMakeLists.txt
+++ b/bin/elasticurl/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${ELASTICURL_PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${ELASTICURL_PROJECT_NAME} aws-c-http)
+target_link_libraries(${ELASTICURL_PROJECT_NAME} PRIVATE aws-c-http)
 
 if (BUILD_SHARED_LIBS AND NOT WIN32)
     message(INFO " elasticurl will be built with shared libs, but you may need to set LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib to run the application")


### PR DESCRIPTION
*Description of changes:*
- The `target_link_libraries` should be either all-keyworded or non-keyworded. For non-keyworded configurations, there is no default, and it can be either PUBLIC or PRIVATE, depending on various configurations. So, explicitly make it private.

Source: https://cmake.org/pipermail/cmake/2016-May/063400.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
