### PR TITLE
Improve Monitoring Report Interval for low allowable_throughput_failure_interval_seconds

### DIFF
--- a/source/connection_monitor.c
+++ b/source/connection_monitor.c
@@ -188,8 +188,10 @@ static void s_destroy(struct aws_crt_statistics_handler *handler) {
 
 static uint64_t s_get_report_interval_ms(struct aws_crt_statistics_handler *handler) {
     (void)handler;
-
-    return 1000;
+    struct aws_statistics_handler_http_connection_monitor_impl *impl = handler->impl;
+    uint64_t allowable_throughput_failure_interval_ms = aws_timestamp_convert(
+        impl->options.allowable_throughput_failure_interval_seconds, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_MILLIS, NULL);
+    return aws_min_u64(1000, allowable_throughput_failure_interval_ms / 3);
 }
 
 static struct aws_crt_statistics_handler_vtable s_http_connection_monitor_vtable = {

--- a/tests/py_localhost/server.py
+++ b/tests/py_localhost/server.py
@@ -268,7 +268,7 @@ class H2Protocol(asyncio.Protocol):
 
             try:
                 # Sleep for a sec to make the out bytes per second slower than the expected
-                time.sleep(1)
+                time.sleep(2)
                 self.conn.send_data(
                     stream_id,
                     data,


### PR DESCRIPTION
*Description of changes:*
The report interval was 1 second by default, which can be slow if `allowable_throughput_failure_interval_seconds` is also low like `1 second` in the [IMDS Client](https://github.com/awslabs/aws-c-auth/blob/main/source/aws_imds_client.c#L168). It took around 3 seconds to figure out if the connection was stuck. This change improves that time to around `1.5 seconds`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
