### PR TITLE
system vtables use full function names, for better grepping

### DIFF
--- a/include/aws/http/private/connection_impl.h
+++ b/include/aws/http/private/connection_impl.h
@@ -20,10 +20,8 @@ struct aws_http_make_request_options;
 struct aws_http_request_handler_options;
 struct aws_http_stream;
 
-typedef int aws_client_bootstrap_new_socket_channel_fn(struct aws_socket_channel_bootstrap_options *options);
-
 struct aws_http_connection_system_vtable {
-    aws_client_bootstrap_new_socket_channel_fn *new_socket_channel;
+    int (*aws_client_bootstrap_new_socket_channel)(struct aws_socket_channel_bootstrap_options *options);
 };
 
 struct aws_http_connection_vtable {

--- a/include/aws/http/private/connection_impl.h
+++ b/include/aws/http/private/connection_impl.h
@@ -20,6 +20,8 @@ struct aws_http_make_request_options;
 struct aws_http_request_handler_options;
 struct aws_http_stream;
 
+/* vtable of functions that aws_http_connection uses to interact with external systems.
+ * tests override the vtable to mock those systems */
 struct aws_http_connection_system_vtable {
     int (*aws_client_bootstrap_new_socket_channel)(struct aws_socket_channel_bootstrap_options *options);
 };

--- a/include/aws/http/private/connection_manager_system_vtable.h
+++ b/include/aws/http/private/connection_manager_system_vtable.h
@@ -12,28 +12,18 @@
 
 struct aws_http_connection_manager;
 
-typedef int(aws_http_connection_manager_create_connection_fn)(const struct aws_http_client_connection_options *options);
-typedef void(aws_http_connection_manager_close_connection_fn)(struct aws_http_connection *connection);
-typedef void(aws_http_connection_release_connection_fn)(struct aws_http_connection *connection);
-typedef bool(aws_http_connection_is_connection_available_fn)(const struct aws_http_connection *connection);
-typedef bool(aws_http_connection_manager_is_callers_thread_fn)(struct aws_channel *channel);
-typedef struct aws_channel *(aws_http_connection_manager_connection_get_channel_fn)(
-    struct aws_http_connection *connection);
-typedef enum aws_http_version(aws_http_connection_manager_connection_get_version_fn)(
-    const struct aws_http_connection *connection);
-
 struct aws_http_connection_manager_system_vtable {
     /*
      * Downstream http functions
      */
-    aws_http_connection_manager_create_connection_fn *create_connection;
-    aws_http_connection_manager_close_connection_fn *close_connection;
-    aws_http_connection_release_connection_fn *release_connection;
-    aws_http_connection_is_connection_available_fn *is_connection_available;
-    aws_io_clock_fn *get_monotonic_time;
-    aws_http_connection_manager_is_callers_thread_fn *is_callers_thread;
-    aws_http_connection_manager_connection_get_channel_fn *connection_get_channel;
-    aws_http_connection_manager_connection_get_version_fn *connection_get_version;
+    int (*aws_http_client_connect)(const struct aws_http_client_connection_options *options);
+    void (*aws_http_connection_close)(struct aws_http_connection *connection);
+    void (*aws_http_connection_release)(struct aws_http_connection *connection);
+    bool (*aws_http_connection_new_requests_allowed)(const struct aws_http_connection *connection);
+    int (*aws_high_res_clock_get_ticks)(uint64_t *timestamp);
+    bool (*aws_channel_thread_is_callers_thread)(struct aws_channel *channel);
+    struct aws_channel *(*aws_http_connection_get_channel)(struct aws_http_connection *connection);
+    enum aws_http_version (*aws_http_connection_get_version)(const struct aws_http_connection *connection);
 };
 
 AWS_HTTP_API

--- a/include/aws/http/private/connection_manager_system_vtable.h
+++ b/include/aws/http/private/connection_manager_system_vtable.h
@@ -12,6 +12,8 @@
 
 struct aws_http_connection_manager;
 
+/* vtable of functions that aws_http_connection_manager uses to interact with external systems.
+ * tests override the vtable to mock those systems */
 struct aws_http_connection_manager_system_vtable {
     /*
      * Downstream http functions

--- a/include/aws/http/private/proxy_impl.h
+++ b/include/aws/http/private/proxy_impl.h
@@ -131,7 +131,9 @@ struct aws_http_proxy_user_data {
 };
 
 struct aws_http_proxy_system_vtable {
-    int (*setup_client_tls)(struct aws_channel_slot *right_of_slot, struct aws_tls_connection_options *tls_options);
+    int (*aws_channel_setup_client_tls)(
+        struct aws_channel_slot *right_of_slot,
+        struct aws_tls_connection_options *tls_options);
 };
 
 AWS_EXTERN_C_BEGIN

--- a/include/aws/http/private/proxy_impl.h
+++ b/include/aws/http/private/proxy_impl.h
@@ -130,6 +130,8 @@ struct aws_http_proxy_user_data {
     const struct aws_host_resolution_config *host_resolution_config;
 };
 
+/* vtable of functions that proxy uses to interact with external systems.
+ * tests override the vtable to mock those systems */
 struct aws_http_proxy_system_vtable {
     int (*aws_channel_setup_client_tls)(
         struct aws_channel_slot *right_of_slot,

--- a/source/connection.c
+++ b/source/connection.c
@@ -27,7 +27,7 @@
 #endif
 
 static struct aws_http_connection_system_vtable s_default_system_vtable = {
-    .new_socket_channel = aws_client_bootstrap_new_socket_channel,
+    .aws_client_bootstrap_new_socket_channel = aws_client_bootstrap_new_socket_channel,
 };
 
 static const struct aws_http_connection_system_vtable *s_system_vtable_ptr = &s_default_system_vtable;
@@ -1114,7 +1114,7 @@ int aws_http_client_connect_internal(
         .host_resolution_override_config = options.host_resolution_config,
     };
 
-    err = s_system_vtable_ptr->new_socket_channel(&channel_options);
+    err = s_system_vtable_ptr->aws_client_bootstrap_new_socket_channel(&channel_options);
 
     if (err) {
         AWS_LOGF_ERROR(

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -1223,7 +1223,7 @@ int aws_http_connection_manager_release_connection(
     s_aws_connection_management_transaction_init(&work, manager);
 
     int result = AWS_OP_ERR;
-    bool should_release_connection = !manager->system_vtable - aws_http_connection_new_requests_allowed(connection);
+    bool should_release_connection = !manager->system_vtable->aws_http_connection_new_requests_allowed(connection);
 
     AWS_LOGF_DEBUG(
         AWS_LS_HTTP_CONNECTION_MANAGER,

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -43,22 +43,22 @@ struct aws_idle_connection {
  * System vtable to use under normal circumstances
  */
 static struct aws_http_connection_manager_system_vtable s_default_system_vtable = {
-    .create_connection = aws_http_client_connect,
-    .release_connection = aws_http_connection_release,
-    .close_connection = aws_http_connection_close,
-    .is_connection_available = aws_http_connection_new_requests_allowed,
-    .get_monotonic_time = aws_high_res_clock_get_ticks,
-    .is_callers_thread = aws_channel_thread_is_callers_thread,
-    .connection_get_channel = aws_http_connection_get_channel,
-    .connection_get_version = aws_http_connection_get_version,
+    .aws_http_client_connect = aws_http_client_connect,
+    .aws_http_connection_release = aws_http_connection_release,
+    .aws_http_connection_close = aws_http_connection_close,
+    .aws_http_connection_new_requests_allowed = aws_http_connection_new_requests_allowed,
+    .aws_high_res_clock_get_ticks = aws_high_res_clock_get_ticks,
+    .aws_channel_thread_is_callers_thread = aws_channel_thread_is_callers_thread,
+    .aws_http_connection_get_channel = aws_http_connection_get_channel,
+    .aws_http_connection_get_version = aws_http_connection_get_version,
 };
 
 const struct aws_http_connection_manager_system_vtable *g_aws_http_connection_manager_default_system_vtable_ptr =
     &s_default_system_vtable;
 
 bool aws_http_connection_manager_system_vtable_is_valid(const struct aws_http_connection_manager_system_vtable *table) {
-    return table->create_connection && table->close_connection && table->release_connection &&
-           table->is_connection_available;
+    return table->aws_http_client_connect && table->aws_http_connection_close && table->aws_http_connection_release &&
+           table->aws_http_connection_new_requests_allowed;
 }
 
 enum aws_http_connection_manager_state_type { AWS_HCMST_UNINITIALIZED, AWS_HCMST_READY, AWS_HCMST_SHUTTING_DOWN };
@@ -433,13 +433,13 @@ static void s_aws_http_connection_manager_complete_acquisitions(
 
         if (pending_acquisition->error_code == AWS_OP_SUCCESS) {
 
-            struct aws_channel *channel =
-                pending_acquisition->manager->system_vtable->connection_get_channel(pending_acquisition->connection);
+            struct aws_channel *channel = pending_acquisition->manager->system_vtable->aws_http_connection_get_channel(
+                pending_acquisition->connection);
             AWS_PRECONDITION(channel);
 
             /* For some workloads, going ahead and moving the connection callback to the connection's thread is a
              * substantial performance improvement so let's do that */
-            if (!pending_acquisition->manager->system_vtable->is_callers_thread(channel)) {
+            if (!pending_acquisition->manager->system_vtable->aws_channel_thread_is_callers_thread(channel)) {
                 aws_channel_task_init(
                     &pending_acquisition->acquisition_task,
                     s_connection_acquisition_task,
@@ -776,7 +776,7 @@ static void s_schedule_connection_culling(struct aws_http_connection_manager *ma
          * culling interval from now.
          */
         uint64_t now = 0;
-        manager->system_vtable->get_monotonic_time(&now);
+        manager->system_vtable->aws_high_res_clock_get_ticks(&now);
         cull_task_time =
             now + aws_timestamp_convert(
                       manager->max_connection_idle_in_milliseconds, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL);
@@ -1024,7 +1024,7 @@ static int s_aws_http_connection_manager_new_connection(struct aws_http_connecti
         options.proxy_options = &proxy_options;
     }
 
-    if (manager->system_vtable->create_connection(&options)) {
+    if (manager->system_vtable->aws_http_client_connect(&options)) {
         AWS_LOGF_ERROR(
             AWS_LS_HTTP_CONNECTION_MANAGER,
             "id=%p: http connection creation failed with error code %d(%s)",
@@ -1061,7 +1061,7 @@ static void s_aws_http_connection_manager_execute_transaction(struct aws_connect
             "id=%p: Releasing connection (id=%p)",
             (void *)manager,
             (void *)idle_connection->connection);
-        manager->system_vtable->release_connection(idle_connection->connection);
+        manager->system_vtable->aws_http_connection_release(idle_connection->connection);
         aws_mem_release(idle_connection->allocator, idle_connection);
     }
 
@@ -1071,7 +1071,7 @@ static void s_aws_http_connection_manager_execute_transaction(struct aws_connect
             "id=%p: Releasing connection (id=%p)",
             (void *)manager,
             (void *)work->connection_to_release);
-        manager->system_vtable->release_connection(work->connection_to_release);
+        manager->system_vtable->aws_http_connection_release(work->connection_to_release);
     }
 
     /*
@@ -1194,7 +1194,7 @@ static int s_idle_connection(struct aws_http_connection_manager *manager, struct
     idle_connection->connection = connection;
 
     uint64_t idle_start_timestamp = 0;
-    if (manager->system_vtable->get_monotonic_time(&idle_start_timestamp)) {
+    if (manager->system_vtable->aws_high_res_clock_get_ticks(&idle_start_timestamp)) {
         goto on_error;
     }
 
@@ -1223,7 +1223,7 @@ int aws_http_connection_manager_release_connection(
     s_aws_connection_management_transaction_init(&work, manager);
 
     int result = AWS_OP_ERR;
-    bool should_release_connection = !manager->system_vtable->is_connection_available(connection);
+    bool should_release_connection = !manager->system_vtable - aws_http_connection_new_requests_allowed(connection);
 
     AWS_LOGF_DEBUG(
         AWS_LS_HTTP_CONNECTION_MANAGER,
@@ -1413,7 +1413,8 @@ static void s_aws_http_connection_manager_on_connection_setup(
         s_connection_manager_internal_ref_increase(manager, AWS_HCMCT_OPEN_CONNECTION, 1);
     }
 
-    if (connection != NULL && manager->system_vtable->connection_get_version(connection) == AWS_HTTP_VERSION_2) {
+    if (connection != NULL &&
+        manager->system_vtable->aws_http_connection_get_version(connection) == AWS_HTTP_VERSION_2) {
         /* If the manager is shutting down, we will still wait for the settings, since we don't have map for connections
          */
         ++manager->pending_settings_count;
@@ -1492,7 +1493,7 @@ static void s_cull_idle_connections(struct aws_http_connection_manager *manager)
     }
 
     uint64_t now = 0;
-    if (manager->system_vtable->get_monotonic_time(&now)) {
+    if (manager->system_vtable->aws_high_res_clock_get_ticks(&now)) {
         return;
     }
 

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -39,7 +39,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_proxy_no_verify_peer_env_var, "AWS_PROXY_NO_VER
 #endif
 
 static struct aws_http_proxy_system_vtable s_default_vtable = {
-    .setup_client_tls = &aws_channel_setup_client_tls,
+    .aws_channel_setup_client_tls = &aws_channel_setup_client_tls,
 };
 
 static struct aws_http_proxy_system_vtable *s_vtable = &s_default_vtable;
@@ -772,7 +772,7 @@ static void s_aws_http_on_stream_complete_tunnel_proxy(
             last_slot = last_slot->adj_right;
         }
 
-        if (s_vtable->setup_client_tls(last_slot, context->original_tls_options)) {
+        if (s_vtable->aws_channel_setup_client_tls(last_slot, context->original_tls_options)) {
             AWS_LOGF_ERROR(
                 AWS_LS_HTTP_CONNECTION,
                 "(%p) Proxy connection failed to start TLS negotiation with error %d(%s)",

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -155,7 +155,7 @@ static int s_cm_tester_init(struct cm_tester_options *options) {
 
     aws_io_clock_fn *clock_fn = &aws_high_res_clock_get_ticks;
     if (options->mock_table) {
-        clock_fn = options->mock_table->get_monotonic_time;
+        clock_fn = options->mock_table->aws_high_res_clock_get_ticks;
     }
 
     tester->event_loop_group = aws_event_loop_group_new(tester->allocator, clock_fn, 1, s_new_event_loop, NULL, NULL);
@@ -304,7 +304,7 @@ release:
 
             if (close_first) {
                 if (tester->mock_table) {
-                    tester->mock_table->close_connection(connection);
+                    tester->mock_table->aws_http_connection_close(connection);
                 } else {
                     aws_http_connection_close(connection);
                 }
@@ -809,14 +809,14 @@ static enum aws_http_version s_aws_http_connection_manager_connection_get_versio
 }
 
 static struct aws_http_connection_manager_system_vtable s_synchronous_mocks = {
-    .create_connection = s_aws_http_connection_manager_create_connection_sync_mock,
-    .release_connection = s_aws_http_connection_manager_release_connection_sync_mock,
-    .close_connection = s_aws_http_connection_manager_close_connection_sync_mock,
-    .is_connection_available = s_aws_http_connection_manager_is_connection_available_sync_mock,
-    .get_monotonic_time = aws_high_res_clock_get_ticks,
-    .connection_get_channel = s_aws_http_connection_manager_connection_get_channel_sync_mock,
-    .is_callers_thread = s_aws_http_connection_manager_is_callers_thread_sync_mock,
-    .connection_get_version = s_aws_http_connection_manager_connection_get_version_sync_mock,
+    .aws_http_client_connect = s_aws_http_connection_manager_create_connection_sync_mock,
+    .aws_http_connection_release = s_aws_http_connection_manager_release_connection_sync_mock,
+    .aws_http_connection_close = s_aws_http_connection_manager_close_connection_sync_mock,
+    .aws_http_connection_new_requests_allowed = s_aws_http_connection_manager_is_connection_available_sync_mock,
+    .aws_high_res_clock_get_ticks = aws_high_res_clock_get_ticks,
+    .aws_http_connection_get_channel = s_aws_http_connection_manager_connection_get_channel_sync_mock,
+    .aws_channel_thread_is_callers_thread = s_aws_http_connection_manager_is_callers_thread_sync_mock,
+    .aws_http_connection_get_version = s_aws_http_connection_manager_connection_get_version_sync_mock,
 };
 
 static int s_test_connection_manager_acquire_release_mix_synchronous(struct aws_allocator *allocator, void *ctx) {
@@ -934,14 +934,14 @@ static int s_test_connection_manager_proxy_setup_shutdown(struct aws_allocator *
 AWS_TEST_CASE(test_connection_manager_proxy_setup_shutdown, s_test_connection_manager_proxy_setup_shutdown);
 
 static struct aws_http_connection_manager_system_vtable s_idle_mocks = {
-    .create_connection = s_aws_http_connection_manager_create_connection_sync_mock,
-    .release_connection = s_aws_http_connection_manager_release_connection_sync_mock,
-    .close_connection = s_aws_http_connection_manager_close_connection_sync_mock,
-    .is_connection_available = s_aws_http_connection_manager_is_connection_available_sync_mock,
-    .get_monotonic_time = s_tester_get_mock_time,
-    .connection_get_channel = s_aws_http_connection_manager_connection_get_channel_sync_mock,
-    .is_callers_thread = s_aws_http_connection_manager_is_callers_thread_sync_mock,
-    .connection_get_version = s_aws_http_connection_manager_connection_get_version_sync_mock,
+    .aws_http_client_connect = s_aws_http_connection_manager_create_connection_sync_mock,
+    .aws_http_connection_release = s_aws_http_connection_manager_release_connection_sync_mock,
+    .aws_http_connection_close = s_aws_http_connection_manager_close_connection_sync_mock,
+    .aws_http_connection_new_requests_allowed = s_aws_http_connection_manager_is_connection_available_sync_mock,
+    .aws_high_res_clock_get_ticks = s_tester_get_mock_time,
+    .aws_http_connection_get_channel = s_aws_http_connection_manager_connection_get_channel_sync_mock,
+    .aws_channel_thread_is_callers_thread = s_aws_http_connection_manager_is_callers_thread_sync_mock,
+    .aws_http_connection_get_version = s_aws_http_connection_manager_connection_get_version_sync_mock,
 };
 
 static int s_register_acquired_connections(struct aws_array_list *seen_connections) {

--- a/tests/test_proxy.c
+++ b/tests/test_proxy.c
@@ -141,7 +141,7 @@ static int s_test_proxy_setup_client_tls(
 }
 
 struct aws_http_proxy_system_vtable s_proxy_table_for_tls = {
-    .setup_client_tls = s_test_proxy_setup_client_tls,
+    .aws_channel_setup_client_tls = s_test_proxy_setup_client_tls,
 };
 
 /*
@@ -208,7 +208,7 @@ static int s_test_aws_proxy_new_socket_channel(struct aws_socket_channel_bootstr
 }
 
 struct aws_http_connection_system_vtable s_proxy_connection_system_vtable = {
-    .new_socket_channel = s_test_aws_proxy_new_socket_channel,
+    .aws_client_bootstrap_new_socket_channel = s_test_aws_proxy_new_socket_channel,
 };
 
 struct mocked_proxy_test_options {

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -692,9 +692,9 @@ static int s_sm_tester_offer_waiting_connections(void) {
 
 static struct aws_http_connection_manager_system_vtable s_mocks;
 
-static void s_override_cm_connect_function(aws_http_connection_manager_create_connection_fn *fn) {
+static void s_override_cm_connect_function(int (*fn)(const struct aws_http_client_connection_options *options)) {
     s_mocks = *g_aws_http_connection_manager_default_system_vtable_ptr;
-    s_mocks.create_connection = fn;
+    s_mocks.aws_http_client_connect = fn;
     s_tester.connection_manager = s_tester.stream_manager->connection_manager;
     aws_http_connection_manager_set_system_vtable(s_tester.connection_manager, &s_mocks);
 }


### PR DESCRIPTION
*Issue #:* https://github.com/awslabs/aws-c-http/issues/358

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
