### PR TITLE
sizeof('c')=4, not 1: fix overallocation

### DIFF
--- a/source/h1_encoder.c
+++ b/source/h1_encoder.c
@@ -489,9 +489,9 @@ static size_t s_calculate_chunk_line_size(const struct aws_http1_chunk_options *
     size_t chunk_line_size = MAX_ASCII_HEX_CHUNK_STR_SIZE + CRLF_SIZE;
     for (size_t i = 0; i < options->num_extensions; ++i) {
         struct aws_http1_chunk_extension *chunk_extension = options->extensions + i;
-        chunk_line_size += sizeof(';');
+        chunk_line_size += 1 /* ; */;
         chunk_line_size += chunk_extension->key.len;
-        chunk_line_size += sizeof('=');
+        chunk_line_size += 1 /* = */;
         chunk_line_size += chunk_extension->value.len;
     }
     return chunk_line_size;


### PR DESCRIPTION
*Description of changes:*
Both of these are sizeof(int), so 4 instead of 1. They are meant to be 1 because they correspond to chars.

As found by DCS `[^._]sizeof[ (]'.{1,2}' filetype:c`

Ref: https://paste.sr.ht/~nabijaczleweli/6ee9ccf301a2651afb693bff46e3671d3f7cdd89
Ref: https://101010.pl/@nabijaczleweli/111587138076843793


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
