### PR TITLE
adapt change from "TLS deliver buffer data during shutdown"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.55
+  BUILDER_VERSION: v0.9.61
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         python .\aws-c-http\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-http\build\aws-c-http
 
   osx:
-    runs-on: macos-12 # latest
+    runs-on: macos-14 # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |
@@ -161,7 +161,7 @@ jobs:
         python3 builder.pyz build -p aws-c-http --cmake-extra=-DENABLE_LOCALHOST_INTEGRATION_TESTS=ON --config Debug
 
   localhost-test-mac:
-    runs-on: macos-11 # latest
+    runs-on: macos-14 # latest
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         python3 builder.pyz build -p aws-c-http --cmake-extra=-DENABLE_LOCALHOST_INTEGRATION_TESTS=ON --config Debug
 
   localhost-test-mac:
-    runs-on: macos-14 # latest
+    runs-on: macos-13 # not use macos-14. It hangs to connect to local socket on macos-14. Not sure why🤷‍♂️
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/include/aws/http/private/h1_connection.h
+++ b/include/aws/http/private/h1_connection.h
@@ -128,7 +128,9 @@ struct aws_h1_connection {
         /* If non-zero, reason to immediately reject new streams. (ex: closing) */
         int new_stream_error_code;
 
-        /* User requested shutdown error code. */
+        /* If true, user has called connection_close() or stream_cancel(),
+         * but the cross_thread_work_task hasn't processed it yet */
+        bool shutdown_requested;
         int shutdown_requested_error_code;
 
         /* See `cross_thread_work_task` */
@@ -136,9 +138,6 @@ struct aws_h1_connection {
 
         /* For checking status from outside the event-loop thread. */
         bool is_open : 1;
-
-        /* User requested shutdown or not. */
-        bool shutdown_requested : 1;
     } synced_data;
 };
 

--- a/include/aws/http/private/h1_connection.h
+++ b/include/aws/http/private/h1_connection.h
@@ -128,12 +128,17 @@ struct aws_h1_connection {
         /* If non-zero, reason to immediately reject new streams. (ex: closing) */
         int new_stream_error_code;
 
+        /* User requested shutdown error code. */
+        int shutdown_requested_error_code;
+
         /* See `cross_thread_work_task` */
         bool is_cross_thread_work_task_scheduled : 1;
 
         /* For checking status from outside the event-loop thread. */
         bool is_open : 1;
 
+        /* User requested shutdown or not. */
+        bool shutdown_requested : 1;
     } synced_data;
 };
 

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -146,7 +146,7 @@ static void s_stop(
         connection->thread_data.is_reading_stopped = true;
         /* Increase the window size after shutdown starts, to prevent deadlock when data still pending in the TLS
          * handler. */
-        connection->base.channel_slot->window_size = SIZE_MAX;
+        aws_channel_slot_increment_read_window(connection->base.channel_slot, SIZE_MAX);
     }
 
     if (stop_writing) {

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -144,9 +144,6 @@ static void s_stop(
     if (stop_reading) {
         AWS_ASSERT(aws_channel_thread_is_callers_thread(connection->base.channel_slot->channel));
         connection->thread_data.is_reading_stopped = true;
-        /* Increase the window size after shutdown starts, to prevent deadlock when data still pending in the TLS
-         * handler. */
-        aws_channel_slot_increment_read_window(connection->base.channel_slot, SIZE_MAX);
     }
 
     if (stop_writing) {
@@ -172,6 +169,11 @@ static void s_stop(
             aws_error_name(error_code));
 
         aws_channel_shutdown(connection->base.channel_slot->channel, error_code);
+        if (stop_reading) {
+            /* Increase the window size after shutdown starts, to prevent deadlock when data still pending in the TLS
+             * handler. */
+            aws_channel_slot_increment_read_window(connection->base.channel_slot, SIZE_MAX);
+        }
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -159,6 +159,7 @@ add_test_case(strutil_is_http_pseudo_header_name)
 
 add_net_test_case(tls_download_medium_file_h1)
 add_net_test_case(tls_download_medium_file_h2)
+add_net_test_case(test_tls_download_shutdown_with_window_size_0)
 
 add_test_case(websocket_decoder_sanity_check)
 add_test_case(websocket_decoder_simplest_frame)

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -508,9 +508,6 @@ AWS_TEST_CASE(connection_setup_shutdown, s_test_connection_setup_shutdown);
 static int s_test_connection_setup_shutdown_tls(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-#ifdef __APPLE__ /* Something is wrong with APPLE */
-    return AWS_OP_SUCCESS;
-#endif
     struct tester_options options = {
         .alloc = allocator,
         .tls = true,

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -243,3 +243,122 @@ static int s_tls_download_medium_file_h2(struct aws_allocator *allocator, void *
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(tls_download_medium_file_h2, s_tls_download_medium_file_h2);
+
+static int s_test_tls_download_shutdown_with_window_size_0(struct aws_allocator *allocator, void *ctx) {
+
+    aws_http_library_init(allocator);
+    struct aws_byte_cursor uri_str =
+        aws_byte_cursor_from_c_str("https://aws-crt-test-stuff.s3.amazonaws.com/http_test_doc.txt");
+    struct aws_uri uri;
+    AWS_ZERO_STRUCT(uri);
+    aws_uri_init_parse(&uri, allocator, &uri_str);
+
+    struct aws_socket_options socket_options = {
+        .type = AWS_SOCKET_STREAM,
+        .domain = AWS_SOCKET_IPV4,
+        .connect_timeout_ms =
+            (uint32_t)aws_timestamp_convert(TEST_TIMEOUT_SEC, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_MILLIS, NULL),
+    };
+
+    struct test_ctx test;
+    AWS_ZERO_STRUCT(test);
+    test.alloc = allocator;
+
+    aws_mutex_init(&test.wait_lock);
+    aws_condition_variable_init(&test.wait_cvar);
+
+    test.event_loop_group = aws_event_loop_group_new_default(test.alloc, 1, NULL);
+
+    struct aws_host_resolver_default_options resolver_options = {
+        .el_group = test.event_loop_group,
+        .max_entries = 1,
+    };
+
+    test.host_resolver = aws_host_resolver_new_default(test.alloc, &resolver_options);
+
+    struct aws_client_bootstrap_options bootstrap_options = {
+        .event_loop_group = test.event_loop_group,
+        .host_resolver = test.host_resolver,
+    };
+    ASSERT_NOT_NULL(test.client_bootstrap = aws_client_bootstrap_new(test.alloc, &bootstrap_options));
+    struct aws_tls_ctx_options tls_ctx_options;
+    aws_tls_ctx_options_init_default_client(&tls_ctx_options, allocator);
+    char *apln = "http/1.1";
+    aws_tls_ctx_options_set_alpn_list(&tls_ctx_options, apln);
+    ASSERT_NOT_NULL(test.tls_ctx = aws_tls_client_ctx_new(allocator, &tls_ctx_options));
+    struct aws_tls_connection_options tls_connection_options;
+    aws_tls_connection_options_init_from_ctx(&tls_connection_options, test.tls_ctx);
+    aws_tls_connection_options_set_server_name(
+        &tls_connection_options, allocator, (struct aws_byte_cursor *)aws_uri_host_name(&uri));
+    struct aws_http_client_connection_options http_options = AWS_HTTP_CLIENT_CONNECTION_OPTIONS_INIT;
+    http_options.allocator = test.alloc;
+    http_options.bootstrap = test.client_bootstrap;
+    http_options.host_name = *aws_uri_host_name(&uri);
+    http_options.port = 443;
+    http_options.on_setup = s_on_connection_setup;
+    http_options.on_shutdown = s_on_connection_shutdown;
+    http_options.socket_options = &socket_options;
+    http_options.tls_options = &tls_connection_options;
+    http_options.user_data = &test;
+    http_options.manual_window_management = true;
+    http_options.initial_window_size = 100;
+
+    ASSERT_SUCCESS(aws_http_client_connect(&http_options));
+    ASSERT_SUCCESS(s_test_wait(&test, s_test_connection_setup_pred));
+    ASSERT_INT_EQUALS(0, test.wait_result);
+    ASSERT_NOT_NULL(test.client_connection);
+    ASSERT_INT_EQUALS(aws_http_connection_get_version(test.client_connection), AWS_HTTP_VERSION_1_1);
+
+    struct aws_http_message *request = aws_http_message_new_request(allocator);
+    ASSERT_NOT_NULL(request);
+    ASSERT_SUCCESS(aws_http_message_set_request_method(request, aws_http_method_get));
+    ASSERT_SUCCESS(aws_http_message_set_request_path(request, *aws_uri_path_and_query(&uri)));
+
+    struct aws_http_header header_host = {
+        .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Host"),
+        .value = *aws_uri_host_name(&uri),
+    };
+    ASSERT_SUCCESS(aws_http_message_add_header(request, header_host));
+
+    struct aws_http_make_request_options req_options = {
+        .self_size = sizeof(req_options),
+        .request = request,
+        .on_response_body = s_on_stream_body,
+        .on_complete = s_on_stream_complete,
+        .user_data = &test,
+    };
+
+    ASSERT_NOT_NULL(test.stream = aws_http_connection_make_request(test.client_connection, &req_options));
+    aws_http_stream_activate(test.stream);
+
+    /* wait for the request to complete */
+    aws_thread_current_sleep(aws_timestamp_convert(2, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL));
+    aws_http_connection_close(test.client_connection);
+
+    aws_http_stream_release(test.stream);
+    test.stream = NULL;
+
+    aws_http_connection_release(test.client_connection);
+    ASSERT_SUCCESS(s_test_wait(&test, s_test_connection_shutdown_pred));
+    ASSERT_INT_EQUALS(100, test.body_size);
+
+    aws_http_message_destroy(request);
+
+    aws_client_bootstrap_release(test.client_bootstrap);
+    aws_host_resolver_release(test.host_resolver);
+    aws_event_loop_group_release(test.event_loop_group);
+
+    aws_tls_ctx_options_clean_up(&tls_ctx_options);
+    aws_tls_connection_options_clean_up(&tls_connection_options);
+    aws_tls_ctx_release(test.tls_ctx);
+
+    aws_uri_clean_up(&uri);
+    aws_http_library_clean_up();
+
+    aws_mutex_clean_up(&test.wait_lock);
+    aws_condition_variable_clean_up(&test.wait_cvar);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(test_tls_download_shutdown_with_window_size_0, s_test_tls_download_shutdown_with_window_size_0);

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -254,6 +254,7 @@ static int s_tls_download_medium_file_h2(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(tls_download_medium_file_h2, s_tls_download_medium_file_h2);
 
 static int s_test_tls_download_shutdown_with_window_size_0(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
 
     aws_http_library_init(allocator);
     struct aws_byte_cursor uri_str =


### PR DESCRIPTION
Change the HTTP/1 connection and websocket to adapt the change from TLS deliver the buffered data during shutdown
- In case of user initial the shutdown process, to prevent hanging, open up the flow control window to max to keep the data flow, but as read has stopped, drop anything from TLS directly. 

No need for HTTP/2, since HTTP/2 has it own flow-control method, and not using the channel flow control.

Other unrelated changes:
- We previously disabled the TLS test for Mac because of https://github.com/actions/runner-images/issues/3861
- After GitHub fixed the issue, we brought back one test but forgot the other one https://github.com/awslabs/aws-c-http/pull/329
- Bring back the test, which should be not skipped now.
- MacOS 11 is gone for github runner image. 


TODO:
- HTTP/1 also has the buffer data will met the same issue during shutdown as TLS handler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
