### PR TITLE
Fix max_pending_connection_acquisitions to respect connection pool size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.62
+  BUILDER_VERSION: v0.9.64
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-http

--- a/include/aws/http/connection_manager.h
+++ b/include/aws/http/connection_manager.h
@@ -135,7 +135,7 @@ struct aws_http_connection_manager_options {
     /*
      * If set to a non-zero value, aws_http_connection_manager_acquire_connection() calls will fail with
      * AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED if there are already pending acquisitions
-     * equal to `max_pending_connection_acquisitions`.
+     * equal to `max_pending_connection_acquisitions` + `max_connections`.
      */
     uint64_t max_pending_connection_acquisitions;
 

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -1311,7 +1311,7 @@ void aws_http_connection_manager_acquire_connection(
     AWS_FATAL_ASSERT(manager->state == AWS_HCMST_READY);
 
     if (manager->max_pending_connection_acquisitions == 0 ||
-        manager->pending_acquisition_count < manager->max_pending_connection_acquisitions) {
+        manager->pending_acquisition_count < manager->max_pending_connection_acquisitions + manager->max_connections) {
         aws_linked_list_push_back(&manager->pending_acquisitions, &request->node);
         ++manager->pending_acquisition_count;
     } else {

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -749,25 +749,30 @@ static int s_test_connection_manager_max_pending_acquisitions(struct aws_allocat
     (void)ctx;
 
     size_t num_connections = 2;
-    size_t num_pending_connections = 3;
+    size_t max_pending_connection_acquisitions = 2;
+    size_t num_connections_pending_error = 4;
     struct cm_tester_options options = {
         .allocator = allocator,
         .max_connections = num_connections,
-        .max_pending_connection_acquisitions = num_connections,
+        .max_pending_connection_acquisitions = max_pending_connection_acquisitions,
     };
 
     ASSERT_SUCCESS(s_cm_tester_init(&options));
 
-    s_acquire_connections(num_connections + num_pending_connections);
+    s_acquire_connections(num_connections + max_pending_connection_acquisitions + num_connections_pending_error);
 
-    ASSERT_SUCCESS(s_wait_on_connection_reply_count(num_connections + num_pending_connections));
-    ASSERT_UINT_EQUALS(num_pending_connections, s_tester.connection_errors);
-    for (size_t i = 0; i < num_pending_connections; i++) {
+    ASSERT_SUCCESS(s_wait_on_connection_reply_count(num_connections + num_connections_pending_error));
+    ASSERT_UINT_EQUALS(num_connections_pending_error, s_tester.connection_errors);
+    for (size_t i = 0; i < num_connections_pending_error; i++) {
         uint32_t error_code;
         aws_array_list_get_at(&s_tester.connection_errors_list, &error_code, i);
         ASSERT_UINT_EQUALS(AWS_ERROR_HTTP_CONNECTION_MANAGER_MAX_PENDING_ACQUISITIONS_EXCEEDED, error_code);
     }
+
     ASSERT_SUCCESS(s_release_connections(num_connections, false));
+    ASSERT_SUCCESS(s_wait_on_connection_reply_count(
+        num_connections + max_pending_connection_acquisitions + num_connections_pending_error));
+    ASSERT_SUCCESS(s_release_connections(max_pending_connection_acquisitions, false));
 
     ASSERT_SUCCESS(s_cm_tester_clean_up());
 


### PR DESCRIPTION
*Description of changes:*
The previous implementation was too aggressive regarding max_pending_connection_acquisitions. If the max_connections were 50 and max_pending_connection_acquisitions was 10, the 11th acquire request failed even though it was within the max connection limit. This PR changes the implementation to prioritize max_connections first and only fail the 61st request. This change is similar to Netty Behavior 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
