### PR TITLE
increase timeout for http integration tests

### DIFF
--- a/integration-testing/http_client_test.py
+++ b/integration-testing/http_client_test.py
@@ -7,7 +7,7 @@ import urllib.request
 import unittest
 import os.path
 
-TIMEOUT = 100
+TIMEOUT = 300
 
 # Accepting multiple args so we can pass something like: python elasticurl.py
 elasticurl_cmd_prefix = sys.argv[1:]


### PR DESCRIPTION
*Issue #, if available:*

- On CI like armv7, we need qenum, which makes the program reaaaaaaalllllyyyyy slow. https://github.com/awslabs/aws-crt-java/actions/runs/10853091537/job/30125644849, it hits the timeout couple times, and the whole test took 2 hours to run. Bump it up just. 

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
