### PR TITLE
Fix CI for GCC-13 on Ubuntu-18 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           #
           # We can bypass this problem by linking with "resolv" manually until we bump 
           # our base Linux image to Ubuntu 22.
-            extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
+          # extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
-        variant:
+        compiler:
           - name: clang-3
           - name: clang-6
           - name: clang-8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           #
           # We can bypass this problem by linking with "resolv" manually until we bump 
           # our base Linux image to Ubuntu 22.
-          # extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
+            extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Build ${{ env.PACKAGE_NAME }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler.name }} ${{ matrix.compiler.extra-build-flag }}
 
   clang-sanitizers:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,32 +48,49 @@ jobs:
     runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
-        compiler:
-          - clang-3
-          - clang-6
-          - clang-8
-          - clang-9
-          - clang-10
-          - clang-11
-          - clang-15
-          - clang-17
-          - gcc-4.8
-          - gcc-5
-          - gcc-6
-          - gcc-7
-          - gcc-8
-          - gcc-11
-          # - gcc-13 TODO: figure out why its not passing
+        variant:
+          - name: clang-3
+          - name: clang-6
+          - name: clang-8
+          - name: clang-9
+          - name: clang-10
+          - name: clang-11
+          - name: clang-15
+          - name: clang-17
+          - name: gcc-4.8
+          - name: gcc-5
+          - name: gcc-6
+          - name: gcc-7
+          - name: gcc-8
+          - name: gcc-11
+          - name: gcc-13
+          # See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue 
+          # has been fixed in LLVM, the fix will probably not propagate to older versions of Ubuntu and GCC 13.1. 
+          #
+          # Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This 
+          # function is used internally by the `getaddrinfo()` system call.
+          #
+          # In our setup (As of December 2024), we are using an Ubuntu 18 Docker image on a newer Ubuntu host. 
+          # However, due to compatibility issues between newer libasan.so in GCC 13.1
+          # and the older Ubuntu image, the linker does not link with `libresolv.so`. 
+          # This results in crashes in `getaddrinfo()` since Ubuntu-18 GLIBC is 2.31.
+          #
+          # This problem does not occur on Ubuntu 22 and newer because GLIBC versions 2.34 
+          # and above include `dn_expand` in `libc.so`, eliminating the dependency on 
+          # `libresolv.so`.
+          #
+          # We can bypass this problem by linking with "resolv" manually until we bump 
+          # our base Linux image to Ubuntu 22.
+            extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ env.CRT_CI_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
-    - name: Build ${{ env.PACKAGE_NAME }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Build ${{ matrix.variant.name }}
+        run: |
+          aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
 
   clang-sanitizers:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,14 +83,14 @@ jobs:
           # our base Linux image to Ubuntu 22.
             extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.CRT_CI_ROLE }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: Build ${{ matrix.variant.name }}
-        run: |
-          aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }}
+      run: |
+        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
 
   clang-sanitizers:
     runs-on: ubuntu-24.04 # latest


### PR DESCRIPTION
See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue has been fixed in LLVM, the fix will not probably propagate to older versions of Ubuntu and GCC-13.1.

Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This function is used internally by the `getaddrinfo()` system call.

In our setup, we are using an Ubuntu 18 Docker image on a newer Ubuntu host. However, due to compatibility issues between newer libasan.so in GCC 13.1 and the older Ubuntu image, the linker does not link with `libresolv.so`. This results in crashes in `getaddrinfo()`.

This problem does not occur on Ubuntu 22 and newer because GLIBC versions 2.34 and above include `dn_expand` in `libc.so`, eliminating the dependency on `libresolv.so`.

We can bypass this problem by linking with "resolv" manually until we bump our base Linux image to Ubuntu 22.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
