### PR TITLE
Add support for server-side websocket upgrade

### DIFF
--- a/include/aws/http/private/h1_encoder.h
+++ b/include/aws/http/private/h1_encoder.h
@@ -48,6 +48,7 @@ struct aws_h1_encoder_message {
     uint64_t content_length;
     bool has_connection_close_header;
     bool has_chunked_encoding_header;
+    bool is_switching_protocols;
 };
 
 enum aws_h1_encoder_state {

--- a/include/aws/http/private/websocket_impl.h
+++ b/include/aws/http/private/websocket_impl.h
@@ -111,5 +111,16 @@ AWS_HTTP_API
 void aws_websocket_client_bootstrap_set_system_vtable(
     const struct aws_websocket_client_bootstrap_system_vtable *system_vtable);
 
+/**
+ * Calculate the value for the Sec-WebSocket-Accept header.
+ * This value is the base64 encoding of a SHA-1 hash of the Sec-WebSocket-Key concatenated with a magic string.
+ * out_buf should be uninitialized.
+ */
+AWS_HTTP_API
+int aws_websocket_calculate_sec_websocket_accept(
+    struct aws_byte_cursor sec_websocket_key,
+    struct aws_byte_buf *out_buf,
+    struct aws_allocator *alloc);
+
 AWS_EXTERN_C_END
 #endif /* AWS_HTTP_WEBSOCKET_IMPL_H */

--- a/source/h1_connection.c
+++ b/source/h1_connection.c
@@ -621,7 +621,8 @@ static void s_stream_complete(struct aws_h1_stream *stream, int error_code) {
      * If this is the end of a successful CONNECT request, mark ourselves as pass-through since the proxy layer
      * will be tacking on a new http handler (and possibly a tls handler in-between).
      */
-    if (error_code == AWS_ERROR_SUCCESS && s_aws_http_stream_was_successful_connect(stream)) {
+    if (error_code == AWS_ERROR_SUCCESS &&
+        (s_aws_http_stream_was_successful_connect(stream) || stream->encoder_message.is_switching_protocols)) {
         if (s_aws_http1_switch_protocols(connection)) {
             error_code = AWS_ERROR_HTTP_PROTOCOL_SWITCH_FAILURE;
             s_shutdown_due_to_error(connection, error_code);

--- a/source/h1_encoder.c
+++ b/source/h1_encoder.c
@@ -371,6 +371,8 @@ int aws_h1_encoder_message_init_from_response(
 
     struct aws_byte_cursor status_text = aws_byte_cursor_from_c_str(aws_http_status_text(status_int));
 
+    message->is_switching_protocols = status_int == AWS_HTTP_STATUS_CODE_101_SWITCHING_PROTOCOLS;
+
     /**
      * Calculate total size needed for outgoing_head_buffer, then write to buffer.
      */

--- a/source/websocket_bootstrap.c
+++ b/source/websocket_bootstrap.c
@@ -89,10 +89,6 @@ struct aws_websocket_client_bootstrap {
 };
 
 static void s_ws_bootstrap_destroy(struct aws_websocket_client_bootstrap *ws_bootstrap);
-static int s_ws_bootstrap_calculate_sec_websocket_accept(
-    struct aws_byte_cursor sec_websocket_key,
-    struct aws_byte_buf *out_buf,
-    struct aws_allocator *alloc);
 static void s_ws_bootstrap_cancel_setup_due_to_err(
     struct aws_websocket_client_bootstrap *ws_bootstrap,
     struct aws_http_connection *http_connection,
@@ -181,7 +177,7 @@ int aws_websocket_client_connect(const struct aws_websocket_client_connection_op
     ws_bootstrap->response_headers = aws_http_headers_new(ws_bootstrap->alloc);
     aws_byte_buf_init(&ws_bootstrap->response_body, ws_bootstrap->alloc, 0);
 
-    if (s_ws_bootstrap_calculate_sec_websocket_accept(
+    if (aws_websocket_calculate_sec_websocket_accept(
             sec_websocket_key, &ws_bootstrap->expected_sec_websocket_accept, ws_bootstrap->alloc)) {
         goto error;
     }
@@ -270,7 +266,7 @@ static void s_ws_bootstrap_destroy(struct aws_websocket_client_bootstrap *ws_boo
  *      "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" but ignoring any leading and
  *      trailing whitespace
  */
-static int s_ws_bootstrap_calculate_sec_websocket_accept(
+int aws_websocket_calculate_sec_websocket_accept(
     struct aws_byte_cursor sec_websocket_key,
     struct aws_byte_buf *out_buf,
     struct aws_allocator *alloc) {

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -161,11 +161,7 @@ static int s_cm_tester_init(struct cm_tester_options *options) {
         clock_fn = options->mock_table->aws_high_res_clock_get_ticks;
     }
 
-    struct aws_event_loop_group_options elg_options = {
-        .loop_count = 1,
-        .clock_override = clock_fn,
-    };
-    tester->event_loop_group = aws_event_loop_group_new(tester->allocator, &elg_options);
+    tester->event_loop_group = aws_event_loop_group_new(tester->allocator, clock_fn, 1, NULL, NULL, NULL);
 
     struct aws_host_resolver_default_options resolver_options = {
         .el_group = tester->event_loop_group,


### PR DESCRIPTION
The main idea here is a new `aws_websocket_upgrade` function that allows creating an `aws_websocket` instance from a server-side stream. In order for the stream to correctly be marked as having switched protocols in `s_stream_complete`, I added a `is_switching_protocols` bool field to the `aws_h1_encoder_message` struct that is checked in `s_stream_complete`.

Usage would then allow calling `aws_websocket_upgrade` from the server-side `on_complete` function of `aws_http_request_handler_options` and using the `aws_websocket` instance as desired as a server websocket.

I recognize that there may be a cleaner or more desirable way to track the `is_switching_protocols`, but after playing around with a few things, this approach seemed pretty simple. If we'd prefer to track this on the `aws_h1_stream` instead, or in some other way, I'm open to ideas. 

I'm also open to other approaches on how to handle/allow the overall `aws_websocket_upgrade`. The other thought I had was perhaps you could pass something like the proposed `aws_websocket_server_upgrade_options` to the server configuration options itself and then `aws_websocket_upgrade` would be called automatically if an incoming websocket upgrade request was detected? i.e. teh websocket response would automatically be sent, the websocket upgraded, and then two `aws_websocket_on_connect` and `aws_websocket_on_connect_shutdown` callback functions would be required? That seemed a little more involved and I wasn't sure if it would even work dependency wise with server bringing in websocket definitions.

I also realize a discussion/issue could have been opened around this, but I've also just been personally curious to dive in and try something out in the project and this has been a fun way to get to know all the http (h1 at least) lifecycle code. Happy to restart if there are ideas on how to do something like this cleaner/simpler starting from scratch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
