### PR TITLE
Move h1_stream variables, to make thread usage more explicit

### DIFF
--- a/include/aws/http/private/h1_stream.h
+++ b/include/aws/http/private/h1_stream.h
@@ -40,23 +40,21 @@ struct aws_h1_stream {
      */
     struct aws_channel_task cross_thread_work_task;
 
-    /* Message (derived from outgoing request or response) to be submitted to encoder */
-    struct aws_h1_encoder_message encoder_message;
-
-    bool is_outgoing_message_done;
-
-    bool is_incoming_message_done;
-    bool is_incoming_head_done;
-
-    /* If true, this is the last stream the connection should process.
-     * See RFC-7230 Section 6: Connection Management. */
-    bool is_final_stream;
-
-    /* Buffer for incoming data that needs to stick around. */
-    struct aws_byte_buf incoming_storage_buf;
-
     struct {
-        /* TODO: move most other members in here */
+        /* Message (derived from outgoing request or response) to be submitted to encoder */
+        struct aws_h1_encoder_message encoder_message;
+
+        bool is_outgoing_message_done;
+
+        bool is_incoming_message_done;
+        bool is_incoming_head_done;
+
+        /* If true, this is the last stream the connection should process.
+         * See RFC-7230 Section 6: Connection Management. */
+        bool is_final_stream;
+
+        /* Buffer for incoming data that needs to stick around. */
+        struct aws_byte_buf incoming_storage_buf;
 
         /* List of `struct aws_h1_chunk`, used for chunked encoding.
          * Encoder completes/frees/pops front chunk when it's done sending. */
@@ -77,12 +75,16 @@ struct aws_h1_stream {
      * Sharing a lock is fine because it's rare for an HTTP/1 connection
      * to have more than one stream at a time. */
     struct {
+        /* Outgoing response on "request handler" stream which has been submitted by user,
+         * but hasn't yet moved to thread_data.encoder_message. */
+        struct aws_h1_encoder_message pending_outgoing_response;
+
         /* List of `struct aws_h1_chunk` which have been submitted by user,
-         * but haven't yet moved to encoder_message.pending_chunk_list where the encoder will find them. */
+         * but haven't yet moved to thread_data.encoder_message.pending_chunk_list where the encoder will find them. */
         struct aws_linked_list pending_chunk_list;
 
         /* trailing headers which have been submitted by user,
-         * but haven't yet moved to encoder_message where the encoder will find them. */
+         * but haven't yet moved to thread_data.encoder_message where the encoder will find them. */
         struct aws_h1_trailer *pending_trailer;
 
         enum aws_h1_stream_api_state api_state;

--- a/tests/test_connection_manager.c
+++ b/tests/test_connection_manager.c
@@ -1564,7 +1564,7 @@ static int s_aws_http_on_incoming_header_block_done_proxy_test(
     struct cm_tester *tester = &s_tester;
     if (aws_http_stream_get_incoming_response_status(stream, &s_response_status_code) == AWS_OP_SUCCESS) {
         aws_mutex_lock(&tester->lock);
-        tester->proxy_request_successful = s_response_status_code == 200;
+        tester->proxy_request_successful = s_response_status_code / 100 == 2;
         aws_mutex_unlock(&tester->lock);
     }
 
@@ -1771,7 +1771,7 @@ static int s_proxy_integration_test_helper_general(
     aws_http_stream_activate(stream);
 
     ASSERT_SUCCESS(s_wait_on_proxy_request_complete());
-    ASSERT_TRUE(s_response_status_code == 200);
+    ASSERT_TRUE(s_response_status_code / 100 == 2);
 
     aws_http_stream_release(stream);
     aws_http_message_destroy(request);

--- a/tests/test_localhost_integ.c
+++ b/tests/test_localhost_integ.c
@@ -78,7 +78,6 @@ struct tester {
     size_t stream_completed_count;
     size_t stream_complete_errors;
     size_t stream_200_count;
-    size_t stream_4xx_count;
     size_t stream_status_not_200_count;
 
     uint64_t num_sen_received;
@@ -187,10 +186,9 @@ static void s_tester_on_stream_completed(struct aws_http_stream *stream, int err
             ++s_tester.stream_complete_errors;
             s_tester.stream_completed_error_code = aws_last_error();
         } else {
-            if (status == 200) {
+            if (status / 100 == 2) {
                 s_tester.stream_completed_with_200 = true;
                 ++s_tester.stream_200_count;
-            } else if (status / 100 == 4) {
             } else {
                 ++s_tester.stream_status_not_200_count;
             }

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -500,7 +500,7 @@ static void s_sm_tester_on_stream_complete(struct aws_http_stream *stream, int e
             ++s_tester.stream_complete_errors;
             s_tester.stream_completed_error_code = aws_last_error();
         } else {
-            if (status == 200) {
+            if (status / 100 == 2) {
                 ++s_tester.stream_200_count;
             } else {
                 ++s_tester.stream_status_not_200_count;


### PR DESCRIPTION
Some cleanup before embarking on major plumbing...

While developing HTTP/1, we stumbled into the pattern of grouping variables under `thread_data` or `synced_data`, so it was more explicit how they should be accessed. But we never moved ALL the variables into the proper groups. We had a TODO about this. Now it is TODONE.

Also: Fix some flaky integration tests by accepting any "2xx" status-code, not just literal "200. I observed these tests failing when they sometimes got 202, instead of 200: h2_sm_acquire_stream & h2_sm_acquire_stream_multiple_connections. But I applied the same fix to any other test I found that strictly checked for 200.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
