### PR TITLE
Supprt response_first_byte_timeout_ms in ConnectionManagerOptions

### DIFF
--- a/include/aws/http/connection_manager.h
+++ b/include/aws/http/connection_manager.h
@@ -59,6 +59,14 @@ struct aws_http_connection_manager_options {
     struct aws_client_bootstrap *bootstrap;
     size_t initial_window_size;
     const struct aws_socket_options *socket_options;
+    /**
+     * Optional (ignored if 0).
+     * After a request is fully sent, if the server does not begin responding within N milliseconds,
+     * then fail with AWS_ERROR_HTTP_RESPONSE_FIRST_BYTE_TIMEOUT.
+     * This can be overridden per-request by aws_http_make_request_options.response_first_byte_timeout_ms.
+     * TODO: Only supported in HTTP/1.1 now, support it in HTTP/2
+     */
+    uint64_t response_first_byte_timeout_ms;
 
     /**
      * Options to create secure (HTTPS) connections.

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -240,6 +240,8 @@ struct aws_http_connection_manager {
     struct proxy_env_var_settings proxy_ev_settings;
     struct aws_tls_connection_options *proxy_ev_tls_options;
     uint32_t port;
+    uint64_t response_first_byte_timeout_ms;
+
     /*
      * HTTP/2 specific.
      */
@@ -958,6 +960,7 @@ struct aws_http_connection_manager *aws_http_connection_manager_new(
     manager->max_connection_idle_in_milliseconds = options->max_connection_idle_in_milliseconds;
     manager->connection_acquisition_timeout_ms = options->connection_acquisition_timeout_ms;
     manager->max_pending_connection_acquisitions = options->max_pending_connection_acquisitions;
+    manager->response_first_byte_timeout_ms = options->response_first_byte_timeout_ms;
 
     if (options->proxy_ev_settings) {
         manager->proxy_ev_settings = *options->proxy_ev_settings;
@@ -1090,6 +1093,7 @@ static int s_aws_http_connection_manager_new_connection(struct aws_http_connecti
     options.host_name = aws_byte_cursor_from_string(manager->host);
     options.port = manager->port;
     options.initial_window_size = manager->initial_window_size;
+    options.response_first_byte_timeout_ms = manager->response_first_byte_timeout_ms;
     struct aws_socket_options socket_options = manager->socket_options;
     if (aws_array_list_length(&manager->network_interface_names)) {
         struct aws_string *interface_name = NULL;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to bind this value to Java; however, Java only supports the HttpConnectionManager. So add this value as an option to ConnectionManager as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
