### PR TITLE
Fix initial settings for h2

### DIFF
--- a/source/connection.c
+++ b/source/connection.c
@@ -963,7 +963,7 @@ int s_validate_http_client_connection_options(const struct aws_http_client_conne
     }
 
     /* http2_options cannot be NULL here, calling function adds them if they were missing */
-    if (options->http2_options->num_initial_settings > 0 && options->http2_options->initial_settings_array) {
+    if (options->http2_options->num_initial_settings > 0 && !options->http2_options->initial_settings_array) {
         AWS_LOGF_ERROR(
             AWS_LS_HTTP_CONNECTION,
             "static: Invalid connection options, h2 settings count is non-zero but settings array is null");

--- a/tests/test_tls.c
+++ b/tests/test_tls.c
@@ -169,6 +169,15 @@ static int s_test_tls_download_medium_file_general(
     struct test_ctx test;
     ASSERT_SUCCESS(s_test_ctx_init(allocator, &test, h2_required));
 
+    struct aws_http2_setting settings_array[] = {
+        {.id = AWS_HTTP2_SETTINGS_ENABLE_PUSH, .value = 0},
+    };
+
+    struct aws_http2_connection_options http2_options = {
+        .initial_settings_array = settings_array,
+        .num_initial_settings = AWS_ARRAY_SIZE(settings_array),
+    };
+
     struct aws_tls_connection_options tls_connection_options;
     aws_tls_connection_options_init_from_ctx(&tls_connection_options, test.tls_ctx);
     aws_tls_connection_options_set_server_name(
@@ -182,6 +191,7 @@ static int s_test_tls_download_medium_file_general(
     http_options.on_shutdown = s_on_connection_shutdown;
     http_options.socket_options = &socket_options;
     http_options.tls_options = &tls_connection_options;
+    http_options.http2_options = &http2_options;
     http_options.user_data = &test;
 
     ASSERT_SUCCESS(aws_http_client_connect(&http_options));


### PR DESCRIPTION
*Issue #, if available:*

- a bug introduced 5 years ago. https://github.com/awslabs/aws-c-http/pull/277/files#diff-d7eec29a8674c2301bf0ced41b2720d9f20faa547a45348d4140915aa9dd323aR861

*Description of changes:*

- The most interesting part is how this is never caught by our tests :)
- Since our test for connection manager uses a mock connection_new
- while the h2 connection test invokes the internal function directly to create the http/2 connection `aws_http_connection_new_http2_client`. So this code was never actually excised.
- Add it to part of the integration test to excise the code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
