### PR TITLE
Stop sending empty data frame

### DIFF
--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -403,7 +403,7 @@ int aws_h2_encode_data_frame(
         }
     }
 
-    if (body_sub_buf.len == 0 && !body_ends_stream) {
+    if (body_sub_buf.len == 0 && !(flags & AWS_H2_FRAME_F_END_STREAM)) {
         /* This frame would have no useful information, don't even bother sending it */
         goto handle_nothing_to_send_right_now;
     }

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -378,7 +378,6 @@ int aws_h2_encode_data_frame(
     /* Use a sub-buffer to limit where body can go */
     struct aws_byte_buf body_sub_buf =
         aws_byte_buf_from_empty_array(output->buffer + output->len + bytes_preceding_body, max_body);
-
     /* Read body into sub-buffer */
     if (aws_input_stream_read(body_stream, &body_sub_buf)) {
         *body_failed = true;
@@ -401,12 +400,12 @@ int aws_h2_encode_data_frame(
         if (body_sub_buf.len < body_sub_buf.capacity) {
             /* Body stream was unable to provide as much data as it could have */
             *body_stalled = true;
-
-            if (body_sub_buf.len == 0) {
-                /* This frame would have no useful information, don't even bother sending it */
-                goto handle_nothing_to_send_right_now;
-            }
         }
+    }
+
+    if (body_sub_buf.len == 0 && !body_ends_stream) {
+        /* This frame would have no useful information, don't even bother sending it */
+        goto handle_nothing_to_send_right_now;
     }
 
     ENCODER_LOGF(


### PR DESCRIPTION
*Issue #, if available:*

- It's not against the spec to send out empty data frame, but if the data frame is empty and without the end of stream flag, it doesn't contain any useful information. 
- We have the code try to prevent sending them
- However, when the input stream is ending, we fall into a situation that we still send the empty data frame.
- I consider it as an unexpected behavior. 
- Also, some server doesn't support this empty data frame without end of stream, eg: httpbin.org will return GOAWAY with frame size error. 
- Node, http2 also ignores the empty data frame

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
