### PR TITLE
Add openBSD/freeBSD CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,3 +279,49 @@ jobs:
       run: |
         python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
         python builder.pyz build -p aws-c-http --cmake-extra=-DENABLE_LOCALHOST_INTEGRATION_TESTS=ON --config Debug
+
+  freebsd:
+    runs-on: ubuntu-24.04  # latest
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - uses: actions/checkout@v4
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      id: test
+      uses: cross-platform-actions/action@v0.23.0
+      with:
+        operating_system: freebsd
+        architecture: x86-64
+        version: '14.0'
+        cpu_count: 4
+        shell: bash
+        run: |
+          sudo pkg install -y python3 net/py-urllib3
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }}
+
+  openbsd:
+    runs-on: ubuntu-24.04 # latest
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - uses: actions/checkout@v4
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      id: test
+      uses: cross-platform-actions/action@v0.23.0
+      with:
+        operating_system: openbsd
+        architecture: x86-64
+        version: '7.4'
+        cpu_count: 4
+        shell: bash
+        run: |
+          sudo pkg_add py3-urllib3
+          python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+          chmod a+x builder
+          ./builder build -p ${{ env.PACKAGE_NAME }}

--- a/source/no_proxy.c
+++ b/source/no_proxy.c
@@ -9,6 +9,9 @@
 #    include <ws2tcpip.h>
 #else
 #    include <arpa/inet.h>
+#    include <netinet/in.h>
+#    include <sys/socket.h>
+#    include <sys/types.h>
 #endif
 
 enum hostname_type {

--- a/source/no_proxy.c
+++ b/source/no_proxy.c
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+#include <aws/common/byte_order.h>
 #include <aws/common/environment.h>
 #include <aws/http/private/no_proxy.h>
 #include <aws/io/socket.h>
@@ -40,8 +41,8 @@ static bool s_cidr4_match(uint64_t bits, struct aws_string *network_part, uint32
     if (bits > 0 && bits < 32) {
         /* Apply the network mask for CIDR comparison */
         uint32_t mask = 0xffffffff << (32 - bits);
-        uint32_t host_network = ntohl(address);
-        uint32_t check_network = ntohl(check);
+        uint32_t host_network = aws_ntoh32(address);
+        uint32_t check_network = aws_ntoh32(check);
 
         /* Compare the masked addresses */
         return (host_network & mask) == (check_network & mask);


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/awslabs/aws-c-http/issues/523

*Description of changes:*

- Add CI for FreeBSD/OpenBSD
- Apparently, FreeBSD requires different header file for `inet_pton`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
