### PR TITLE
Move away from https://postman-echo.com

### DIFF
--- a/integration-testing/http_client_test.py
+++ b/integration-testing/http_client_test.py
@@ -10,7 +10,7 @@ import os.path
 TIMEOUT = 300
 
 # Global variable for test host
-TEST_HOST = 'reqres.in'
+TEST_HOST = 'jsonplaceholder.typicode.com'
 
 # Accepting multiple args so we can pass something like: python elasticurl.py
 elasticurl_cmd_prefix = sys.argv[1:]
@@ -98,13 +98,13 @@ class SimpleTests(unittest.TestCase):
     def test_simple_get_h1(self):
         """make a simple GET request via HTTP/1.1 and make sure it succeeds"""
         simple_get_args = elasticurl_cmd_prefix + \
-            ['-v', 'TRACE', '--http1_1', f'http://{TEST_HOST}/get']
+            ['-v', 'TRACE', '--http1_1', f'http://{TEST_HOST}/posts']
         run_command(simple_get_args)
 
     def test_simple_post_h1(self):
         """make a simple POST request via HTTP/1.1 to make sure sending data succeeds"""
         simple_post_args = elasticurl_cmd_prefix + ['-v', 'TRACE', '--http1_1', '-P', '-H',
-                                                    'content-type: application/json', '-i', '-d', '\"{\'test\':\'testval\'}\"', f'http://{TEST_HOST}/post']
+                                                    'content-type: application/json', '-i', '-d', '\"{\'test\':\'testval\'}\"', f'http://{TEST_HOST}/posts']
         run_command(simple_post_args)
 
     def test_simple_download_h1(self):
@@ -121,13 +121,13 @@ class SimpleTests(unittest.TestCase):
     def test_simple_get_h2(self):
         """make a simple GET request via HTTP2 and make sure it succeeds"""
         simple_get_args = elasticurl_cmd_prefix + \
-            ['-v', 'TRACE', '--http2', f'https://{TEST_HOST}/get']
+            ['-v', 'TRACE', '--http2', f'https://{TEST_HOST}/posts']
         run_command(simple_get_args)
 
     def test_simple_post_h2(self):
         """make a simple POST request via HTTP2 to make sure sending data succeeds"""
         simple_post_args = elasticurl_cmd_prefix + ['-v', 'TRACE', '--http2', '-P', '-H',
-                                                    'content-type: application/json', '-i', '-d', '\"{\'test\':\'testval\'}\"', f'https://{TEST_HOST}/post']
+                                                    'content-type: application/json', '-i', '-d', '\"{\'test\':\'testval\'}\"', f'https://{TEST_HOST}/posts']
         run_command(simple_post_args)
 
     def test_simple_download_h2(self):

--- a/tests/test_stream_manager.c
+++ b/tests/test_stream_manager.c
@@ -1231,8 +1231,8 @@ TEST_CASE(h2_sm_acquire_stream_multiple_connections) {
 /* Test that makes tons of real streams against real world */
 TEST_CASE(h2_sm_close_connection_on_server_error) {
     (void)ctx;
-    /* server that will return 500 status code all the time. */
-    struct aws_byte_cursor uri_cursor = aws_byte_cursor_from_c_str("https://reqres.in/status/500");
+    /* page not exist. */
+    struct aws_byte_cursor uri_cursor = aws_byte_cursor_from_c_str("https://www.amazon.com/non-exists");
     struct sm_tester_options options = {
         .max_connections = 1,
         .max_concurrent_streams_per_connection = 10,


### PR DESCRIPTION
*Issue #, if available:*
- Postman-echo.com starts to force TLS1.3 and some algo that openssl 1.1.1 doesn't support for TLS handshake.
- Move to https://jsonplaceholder.typicode.com/ instead to get around the issue it brought up, which is not an echo server, but fir the current usage for testing with elasticurl.

*Description of changes:*

TODO:
- It's not the first time we met issues against the 3rd party random host for testing. We maybe should consider to have our own local server for the test instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
