### PR TITLE
Configurable ports for HTTP/1.1 mock server

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ cmake --build aws-c-http/build --target install
 
 To run some of the integration tests (start with localhost_integ_*), you need to set up a localhost that echo the request headers from `/echo` back first.
 
-To do that, check [localhost](./tests/py_localhost/) script we have.
+To do that, check [localhost](./tests/mock_server/) script we have.
 
 After that, configure and build your cmake project with `-DENABLE_LOCALHOST_INTEGRATION_TESTS=true` to build the tests with localhost and run them from `ctest --output-on-failure -R localhost_integ_*`.

--- a/bin/h2benchmark/README.md
+++ b/bin/h2benchmark/README.md
@@ -4,7 +4,7 @@ this is a C program mimic the API call benchmark from aws-java-sdk-v2. https://g
 
 It collects how many API calls finish per second. Basically how many request can made per second.
 
-The program connects to the local host that can be found [here](../../tests/py_localhost).
+The program connects to the local host that can be found [here](../../tests/mock_server).
 
 To run the benchmark, build the h2benchmark with aws-c-http as dependency.
 TODO: Currently the configs are all hardcoded.

--- a/tests/mock_server/README.md
+++ b/tests/mock_server/README.md
@@ -100,20 +100,18 @@ pip3 install trio h11
 
 ### Basic Usage (HTTP + HTTPS)
 
-Run both HTTP (port 80) and HTTPS (port 443) servers:
+Run both HTTP (port 8081) and HTTPS (port 8082) servers:
 
 ```bash
-sudo python3 mock_server.py
+python3 mock_server.py
 ```
 
-Note: `sudo` is required for ports 80 and 443 on most systems.
-
-### Test Mode (Custom Port)
+### Custom Ports
 
 Run on a custom port without sudo:
 
 ```bash
-TEST_PORT=8080 python3 mock_server.py
+HTTP_PORT=8080 HTTPS_PORT=8443 python3 mock_server.py
 ```
 
 **Important**: Since this uses a self-signed certificate, clients must disable peer verification.

--- a/tests/mock_server/h11mock_server.py
+++ b/tests/mock_server/h11mock_server.py
@@ -247,15 +247,12 @@ async def serve_ssl(port, cert_file=os.path.join(os.path.dirname(__file__),
 
 
 async def main():
-    test_port = os.environ.get('TEST_PORT')
+    http_port = os.environ.get('HTTP_PORT')
+    https_port = os.environ.get('HTTPS_PORT')
     
-    if test_port:
-        print(f"Running in test mode on port {test_port}")
-        await serve(int(test_port))
-    else:
-        async with trio.open_nursery() as nursery:
-            nursery.start_soon(serve, 80)
-            nursery.start_soon(serve_ssl, 443)
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(serve, 8081 if not http_port else int(http_port))
+        nursery.start_soon(serve_ssl, 8082 if not https_port else int(https_port))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update to change use of default ports as 80 and 443. Make ports configurable from command line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
