### PR TITLE
Revert "Fix CI issues"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,8 @@ jobs:
     runs-on: macos-14
     strategy:
       fail-fast: false
+      matrix:
+        eventloop: ["kqueue", "dispatch_queue"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -248,6 +250,8 @@ jobs:
     runs-on: macos-14
     strategy:
       fail-fast: false
+      matrix:
+        eventloop: ["kqueue", "dispatch_queue"]
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/tests/test_connection.c
+++ b/tests/test_connection.c
@@ -735,11 +735,14 @@ static int s_test_connection_customized_alpn_error_with_unknown_return_string(
     tester.wait_client_connection_num = 1;
     tester.wait_server_connection_num = 1;
 
+#ifndef __APPLE__ /* Server side ALPN doesn't work for MacOS */
     ASSERT_FAILS(s_tester_wait(&tester, s_tester_connection_setup_pred));
     /* Assert that we have the negotiated protocol and error returned from callback */
     ASSERT_TRUE(aws_byte_buf_eq_c_str(&tester.negotiated_protocol, customized_alpn_string));
     ASSERT_INT_EQUALS(aws_last_error(), AWS_ERROR_HTTP_UNSUPPORTED_PROTOCOL);
-
+#else
+    ASSERT_SUCCESS(s_tester_wait(&tester, s_tester_connection_setup_pred));
+#endif
     /* clean up */
     release_all_client_connections(&tester);
     release_all_server_connections(&tester);

--- a/tests/test_proxy.c
+++ b/tests/test_proxy.c
@@ -344,15 +344,8 @@ AWS_TEST_CASE(
 /*
  * For tls-enabled tunneling proxy connections:
  * Test the happy path by verifying CONNECT request, tls upgrade attempt
- * TODO: This test is temporarily disabled on Apple platforms following a breaking change
- * due to migration to the new Apple Network Framework. Investigations underway for rethinking
- * proxy implementation on Apple platforms. Test should be re-enabled post-fix.
  */
 static int s_test_https_tunnel_proxy_connection_success(struct aws_allocator *allocator, void *ctx) {
-#if defined(AWS_OS_APPLE)
-    (void)allocator;
-    return AWS_OP_SKIP;
-#endif
     (void)ctx;
 
     struct mocked_proxy_test_options options = {


### PR DESCRIPTION
Reverts awslabs/aws-c-http#538 since awslabs/aws-c-io#758 has been rolled back temporarily.
