### PR TITLE
Reject duplicate Content-Length header in h1_encoder

### DIFF
--- a/source/h1_encoder.c
+++ b/source/h1_encoder.c
@@ -69,6 +69,10 @@ static int s_scan_outgoing_headers(
                 }
             } break;
             case AWS_HTTP_HEADER_CONTENT_LENGTH: {
+                if (has_content_length_header) {
+                    AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=static: Duplicate Content-Length header");
+                    return aws_raise_error(AWS_ERROR_HTTP_INVALID_HEADER_FIELD);
+                }
                 has_content_length_header = true;
                 if (aws_byte_cursor_utf8_parse_u64(field_value, &encoder_message->content_length)) {
                     AWS_LOGF_ERROR(AWS_LS_HTTP_STREAM, "id=static: Invalid Content-Length");


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reject duplicate Content-Length header using the existing `has_content_length_header`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
