### PR TITLE
Remove unreachable OOM handling

### DIFF
--- a/source/connection.c
+++ b/source/connection.c
@@ -864,7 +864,6 @@ static void s_client_bootstrap_on_channel_setup(
         struct aws_crt_statistics_handler *http_connection_monitor =
             aws_crt_statistics_handler_new_http_connection_monitor(
                 http_bootstrap->alloc, &http_bootstrap->monitoring_options);
-        AWS_ASSERT(http_connection_monitor);
 
         aws_channel_set_statistics_handler(channel, http_connection_monitor);
     }

--- a/source/connection.c
+++ b/source/connection.c
@@ -864,9 +864,7 @@ static void s_client_bootstrap_on_channel_setup(
         struct aws_crt_statistics_handler *http_connection_monitor =
             aws_crt_statistics_handler_new_http_connection_monitor(
                 http_bootstrap->alloc, &http_bootstrap->monitoring_options);
-        if (http_connection_monitor == NULL) {
-            goto error;
-        }
+        AWS_ASSERT(http_connection_monitor);
 
         aws_channel_set_statistics_handler(channel, http_connection_monitor);
     }

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -907,9 +907,6 @@ struct aws_http_connection_manager *aws_http_connection_manager_new(
 
     struct aws_http_connection_manager *manager =
         aws_mem_calloc(allocator, 1, sizeof(struct aws_http_connection_manager));
-    if (manager == NULL) {
-        return NULL;
-    }
 
     manager->allocator = allocator;
 

--- a/source/connection_monitor.c
+++ b/source/connection_monitor.c
@@ -204,15 +204,13 @@ struct aws_crt_statistics_handler *aws_crt_statistics_handler_new_http_connectio
     struct aws_crt_statistics_handler *handler = NULL;
     struct aws_statistics_handler_http_connection_monitor_impl *impl = NULL;
 
-    if (!aws_mem_acquire_many(
-            allocator,
-            2,
-            &handler,
-            sizeof(struct aws_crt_statistics_handler),
-            &impl,
-            sizeof(struct aws_statistics_handler_http_connection_monitor_impl))) {
-        return NULL;
-    }
+    aws_mem_acquire_many(
+        allocator,
+        2,
+        &handler,
+        sizeof(struct aws_crt_statistics_handler),
+        &impl,
+        sizeof(struct aws_statistics_handler_http_connection_monitor_impl));
 
     AWS_ZERO_STRUCT(*handler);
     AWS_ZERO_STRUCT(*impl);

--- a/source/h1_decoder.c
+++ b/source/h1_decoder.c
@@ -706,11 +706,7 @@ static int s_linestate_response(struct aws_h1_decoder *decoder, struct aws_byte_
 struct aws_h1_decoder *aws_h1_decoder_new(struct aws_h1_decoder_params *params) {
     AWS_ASSERT(params);
 
-    struct aws_h1_decoder *decoder = aws_mem_acquire(params->alloc, sizeof(struct aws_h1_decoder));
-    if (!decoder) {
-        return NULL;
-    }
-    AWS_ZERO_STRUCT(*decoder);
+    struct aws_h1_decoder *decoder = aws_mem_calloc(params->alloc, 1, sizeof(struct aws_h1_decoder));
 
     decoder->alloc = params->alloc;
     decoder->user_data = params->user_data;

--- a/source/h1_encoder.c
+++ b/source/h1_encoder.c
@@ -567,10 +567,7 @@ struct aws_h1_chunk *aws_h1_chunk_new(struct aws_allocator *allocator, const str
     struct aws_h1_chunk *chunk;
     size_t chunk_line_size = s_calculate_chunk_line_size(options);
     void *chunk_line_storage;
-    if (!aws_mem_acquire_many(
-            allocator, 2, &chunk, sizeof(struct aws_h1_chunk), &chunk_line_storage, chunk_line_size)) {
-        return NULL;
-    }
+    aws_mem_acquire_many(allocator, 2, &chunk, sizeof(struct aws_h1_chunk), &chunk_line_storage, chunk_line_size);
 
     chunk->allocator = allocator;
     chunk->data = aws_input_stream_acquire(options->chunk_data);

--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -307,9 +307,6 @@ static struct aws_h2_connection *s_connection_new(
     AWS_PRECONDITION(http2_options);
 
     struct aws_h2_connection *connection = aws_mem_calloc(alloc, 1, sizeof(struct aws_h2_connection));
-    if (!connection) {
-        return NULL;
-    }
     connection->base.vtable = &s_h2_connection_vtable;
     connection->base.alloc = alloc;
     connection->base.channel_handler.vtable = &s_h2_connection_vtable.channel_handler_vtable;
@@ -546,16 +543,14 @@ static struct aws_h2_pending_settings *s_new_pending_settings(
 
     size_t settings_storage_size = sizeof(struct aws_http2_setting) * num_settings;
     struct aws_h2_pending_settings *pending_settings;
-    uint8_t *settings_storage;
-    if (!aws_mem_acquire_many(
-            allocator,
-            2,
-            &pending_settings,
-            sizeof(struct aws_h2_pending_settings),
-            &settings_storage,
-            settings_storage_size)) {
-        return NULL;
-    }
+    void *settings_storage;
+    aws_mem_acquire_many(
+        allocator,
+        2,
+        &pending_settings,
+        sizeof(struct aws_h2_pending_settings),
+        &settings_storage,
+        settings_storage_size);
 
     AWS_ZERO_STRUCT(*pending_settings);
     /* We buffer the settings up, in case the caller has freed them when the ACK arrives */
@@ -565,7 +560,7 @@ static struct aws_h2_pending_settings *s_new_pending_settings(
         pending_settings->settings_array[0].id = AWS_HTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
         pending_settings->settings_array[0].value = (uint32_t)initial_window_size;
         /* Move the storage pointer to the second in the list */
-        settings_storage = settings_storage + sizeof(struct aws_http2_setting);
+        settings_storage = (uint8_t *)settings_storage + sizeof(struct aws_http2_setting);
     }
     if (settings_array) {
         /* copy all passed-in settings to the settings storage. */
@@ -586,9 +581,7 @@ static struct aws_h2_pending_ping *s_new_pending_ping(
     aws_http2_on_ping_complete_fn *on_completed) {
 
     struct aws_h2_pending_ping *pending_ping = aws_mem_calloc(allocator, 1, sizeof(struct aws_h2_pending_ping));
-    if (!pending_ping) {
-        return NULL;
-    }
+
     if (optional_opaque_data) {
         memcpy(pending_ping->opaque_data, optional_opaque_data->ptr, AWS_HTTP2_PING_DATA_SIZE);
     }
@@ -1505,9 +1498,6 @@ static struct aws_h2err s_decoder_on_settings(
     struct aws_http2_setting *callback_array = NULL;
     if (num_settings) {
         callback_array = aws_mem_acquire(connection->base.alloc, num_settings * sizeof(struct aws_http2_setting));
-        if (!callback_array) {
-            return aws_h2err_from_last_error();
-        }
     }
     size_t callback_array_num = 0;
 
@@ -2341,9 +2331,6 @@ static int s_connection_change_settings(
         num_settings,
         on_completed,
         user_data);
-    if (!pending_settings) {
-        return AWS_OP_ERR;
-    }
     struct aws_h2_frame *settings_frame =
         aws_h2_frame_new_settings(connection->base.alloc, settings_array, num_settings, false /*ACK*/);
     if (!settings_frame) {

--- a/source/h2_connection.c
+++ b/source/h2_connection.c
@@ -543,7 +543,7 @@ static struct aws_h2_pending_settings *s_new_pending_settings(
 
     size_t settings_storage_size = sizeof(struct aws_http2_setting) * num_settings;
     struct aws_h2_pending_settings *pending_settings;
-    void *settings_storage;
+    uint8_t *settings_storage;
     aws_mem_acquire_many(
         allocator,
         2,
@@ -560,7 +560,7 @@ static struct aws_h2_pending_settings *s_new_pending_settings(
         pending_settings->settings_array[0].id = AWS_HTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
         pending_settings->settings_array[0].value = (uint32_t)initial_window_size;
         /* Move the storage pointer to the second in the list */
-        settings_storage = (uint8_t *)settings_storage + sizeof(struct aws_http2_setting);
+        settings_storage = settings_storage + sizeof(struct aws_http2_setting);
     }
     if (settings_array) {
         /* copy all passed-in settings to the settings storage. */

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -536,9 +536,6 @@ static struct aws_h2_frame *s_frame_new_headers_or_push_promise(
     /* Create */
 
     struct aws_h2_frame_headers *frame = aws_mem_calloc(allocator, 1, sizeof(struct aws_h2_frame_headers));
-    if (!frame) {
-        return NULL;
-    }
 
     if (aws_byte_buf_init(&frame->whole_encoded_header_block, allocator, s_encoded_header_block_reserve)) {
         goto error;
@@ -833,10 +830,7 @@ static struct aws_h2_frame_prebuilt *s_h2_frame_new_prebuilt(
     /* Use single allocation for frame and buffer storage */
     struct aws_h2_frame_prebuilt *frame;
     void *storage;
-    if (!aws_mem_acquire_many(
-            allocator, 2, &frame, sizeof(struct aws_h2_frame_prebuilt), &storage, encoded_frame_len)) {
-        return NULL;
-    }
+    aws_mem_acquire_many(allocator, 2, &frame, sizeof(struct aws_h2_frame_prebuilt), &storage, encoded_frame_len);
 
     AWS_ZERO_STRUCT(*frame);
     s_init_frame_base(&frame->base, allocator, type, &s_frame_prebuilt_vtable, stream_id);

--- a/source/h2_frames.c
+++ b/source/h2_frames.c
@@ -932,9 +932,6 @@ struct aws_h2_frame *aws_h2_frame_new_priority(
 
     struct aws_h2_frame_prebuilt *frame =
         s_h2_frame_new_prebuilt(allocator, AWS_H2_FRAME_T_PRIORITY, stream_id, payload_len, flags);
-    if (!frame) {
-        return NULL;
-    }
 
     /* Write the priority settings */
     s_frame_priority_settings_encode(priority, &frame->encoded_buf);
@@ -962,9 +959,6 @@ struct aws_h2_frame *aws_h2_frame_new_rst_stream(
 
     struct aws_h2_frame_prebuilt *frame =
         s_h2_frame_new_prebuilt(allocator, AWS_H2_FRAME_T_RST_STREAM, stream_id, payload_len, flags);
-    if (!frame) {
-        return NULL;
-    }
 
     /* Write RST_STREAM payload (RFC-7540 6.4):
      * +---------------------------------------------------------------+
@@ -1018,9 +1012,6 @@ struct aws_h2_frame *aws_h2_frame_new_settings(
 
     struct aws_h2_frame_prebuilt *frame =
         s_h2_frame_new_prebuilt(allocator, AWS_H2_FRAME_T_SETTINGS, stream_id, payload_len, flags);
-    if (!frame) {
-        return NULL;
-    }
 
     /* Write the settings, each one is encoded like (RFC-7540 6.5.1):
      * +-------------------------------+
@@ -1055,9 +1046,6 @@ struct aws_h2_frame *aws_h2_frame_new_ping(
 
     struct aws_h2_frame_prebuilt *frame =
         s_h2_frame_new_prebuilt(allocator, AWS_H2_FRAME_T_PING, stream_id, payload_len, flags);
-    if (!frame) {
-        return NULL;
-    }
 
     /* Write the PING payload (RFC-7540 6.7):
      * +---------------------------------------------------------------+
@@ -1110,9 +1098,6 @@ struct aws_h2_frame *aws_h2_frame_new_goaway(
 
     struct aws_h2_frame_prebuilt *frame =
         s_h2_frame_new_prebuilt(allocator, AWS_H2_FRAME_T_GOAWAY, stream_id, payload_len, flags);
-    if (!frame) {
-        return NULL;
-    }
 
     /* Write the GOAWAY payload (RFC-7540 6.8):
      * +-+-------------------------------------------------------------+
@@ -1165,9 +1150,6 @@ struct aws_h2_frame *aws_h2_frame_new_window_update(
 
     struct aws_h2_frame_prebuilt *frame =
         s_h2_frame_new_prebuilt(allocator, AWS_H2_FRAME_T_WINDOW_UPDATE, stream_id, payload_len, flags);
-    if (!frame) {
-        return NULL;
-    }
 
     /* Write the WINDOW_UPDATE payload (RFC-7540 6.9):
      * +-+-------------------------------------------------------------+

--- a/source/hpack.c
+++ b/source/hpack.c
@@ -6,8 +6,6 @@
 
 /* #TODO test empty strings */
 
-/* #TODO remove all OOM error handling in HTTP/2 & HPACK. make functions void if possible */
-
 /* RFC-7540 6.5.2 */
 const size_t s_hpack_dynamic_table_initial_size = 4096;
 const size_t s_hpack_dynamic_table_initial_elements = 512;
@@ -439,6 +437,7 @@ int aws_hpack_insert_header(struct aws_hpack_context *context, const struct aws_
     /* Put the header at the "front" of the table */
     struct aws_http_header *table_header = s_dynamic_table_get(context, 0);
 
+    /* TODO:: We can optimize this with ring buffer. */
     /* allocate memory for the name and value, which will be deallocated whenever the entry is evicted from the table or
      * the table is cleaned up. We keep the pointer in the name pointer of each entry */
     const size_t buf_memory_size = header->name.len + header->value.len;

--- a/source/hpack.c
+++ b/source/hpack.c
@@ -314,9 +314,6 @@ static int s_dynamic_table_resize_buffer(struct aws_hpack_context *context, size
 
     /* Allocate the new buffer */
     new_buffer = aws_mem_calloc(context->allocator, new_max_elements, sizeof(struct aws_http_header));
-    if (!new_buffer) {
-        return AWS_OP_ERR;
-    }
 
     /* Don't bother copying data if old buffer was of size 0 */
     if (AWS_UNLIKELY(context->dynamic_table.num_elements == 0)) {
@@ -442,16 +439,12 @@ int aws_hpack_insert_header(struct aws_hpack_context *context, const struct aws_
     /* Put the header at the "front" of the table */
     struct aws_http_header *table_header = s_dynamic_table_get(context, 0);
 
-    /* TODO:: We can optimize this with ring buffer. */
     /* allocate memory for the name and value, which will be deallocated whenever the entry is evicted from the table or
      * the table is cleaned up. We keep the pointer in the name pointer of each entry */
     const size_t buf_memory_size = header->name.len + header->value.len;
 
     if (buf_memory_size) {
         uint8_t *buf_memory = aws_mem_acquire(context->allocator, buf_memory_size);
-        if (!buf_memory) {
-            return AWS_OP_ERR;
-        }
         struct aws_byte_buf buf = aws_byte_buf_from_empty_array(buf_memory, buf_memory_size);
         /* Copy header, then backup strings into our own allocation */
         *table_header = *header;

--- a/source/http.c
+++ b/source/http.c
@@ -226,7 +226,6 @@ static void s_init_str_to_enum_hash_table(
     for (int i = start_index; i < end_index; ++i) {
         int was_created = 0;
         struct aws_enum_value *enum_value = aws_mem_calloc(alloc, 1, sizeof(struct aws_enum_value));
-        AWS_FATAL_ASSERT(enum_value);
         enum_value->allocator = alloc;
         enum_value->value = i;
 

--- a/source/proxy_connection.c
+++ b/source/proxy_connection.c
@@ -254,8 +254,7 @@ struct aws_http_proxy_user_data *aws_http_proxy_user_data_new_reset_clone(
     if (old_user_data->original_tls_options) {
         /* clone tls options, but redirect user data to what we're creating */
         user_data->original_tls_options = aws_mem_calloc(allocator, 1, sizeof(struct aws_tls_connection_options));
-        if (user_data->original_tls_options == NULL ||
-            aws_tls_connection_options_copy(user_data->original_tls_options, old_user_data->original_tls_options)) {
+        if (aws_tls_connection_options_copy(user_data->original_tls_options, old_user_data->original_tls_options)) {
             goto on_error;
         }
 
@@ -1369,9 +1368,6 @@ static struct aws_http_proxy_config *s_aws_http_proxy_config_new(
     AWS_FATAL_ASSERT(proxy_options != NULL);
 
     struct aws_http_proxy_config *config = aws_mem_calloc(allocator, 1, sizeof(struct aws_http_proxy_config));
-    if (config == NULL) {
-        return NULL;
-    }
 
     config->allocator = allocator;
     config->connection_type = override_proxy_connection_type;
@@ -1494,9 +1490,6 @@ struct aws_http_proxy_config *aws_http_proxy_config_new_clone(
     AWS_FATAL_ASSERT(proxy_config != NULL);
 
     struct aws_http_proxy_config *config = aws_mem_calloc(allocator, 1, sizeof(struct aws_http_proxy_config));
-    if (config == NULL) {
-        return NULL;
-    }
 
     config->connection_type = proxy_config->connection_type;
 
@@ -1611,9 +1604,6 @@ static struct aws_proxied_socket_channel_user_data *s_proxied_socket_channel_use
     struct aws_socket_channel_bootstrap_options *channel_options) {
     struct aws_proxied_socket_channel_user_data *user_data =
         aws_mem_calloc(allocator, 1, sizeof(struct aws_proxied_socket_channel_user_data));
-    if (user_data == NULL) {
-        return NULL;
-    }
 
     user_data->allocator = allocator;
     user_data->original_setup_callback = channel_options->setup_callback;

--- a/tests/test_connection_monitor.c
+++ b/tests/test_connection_monitor.c
@@ -1046,15 +1046,13 @@ static struct aws_crt_statistics_handler *s_aws_crt_statistics_handler_new_http_
     struct aws_crt_statistics_handler *handler = NULL;
     struct mock_http_connection_monitor_impl *impl = NULL;
 
-    if (!aws_mem_acquire_many(
-            allocator,
-            2,
-            &handler,
-            sizeof(struct aws_crt_statistics_handler),
-            &impl,
-            sizeof(struct mock_http_connection_monitor_impl))) {
-        return NULL;
-    }
+    aws_mem_acquire_many(
+        allocator,
+        2,
+        &handler,
+        sizeof(struct aws_crt_statistics_handler),
+        &impl,
+        sizeof(struct mock_http_connection_monitor_impl));
 
     AWS_ZERO_STRUCT(*handler);
     AWS_ZERO_STRUCT(*impl);


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

CRT allocators abort on failure rather than returning NULL. They route through `AWS_PANIC_OOM`, an unconditional `exit(-1)`, so every OOM branch guarded by a NULL check was unreachable.

Removes those checks and the error paths behind them, and folds acquire-then-zero pairs into `aws_mem_calloc`. No assert replaces them: it would be dead in debug and compiled out in release, since the abort happens before control returns.

No behavior change. Existing suite passes unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
