### PR TITLE
Document and pin existing behavior

### DIFF
--- a/include/aws/http/private/h1_connection.h
+++ b/include/aws/http/private/h1_connection.h
@@ -185,8 +185,6 @@ AWS_EXTERN_C_END
 
 /* DO NOT export functions below. They're only used by other .c files in this library */
 
-/* TODO: introduce naming conventions for private header functions */
-
 void aws_h1_connection_lock_synced_data(struct aws_h1_connection *connection);
 void aws_h1_connection_unlock_synced_data(struct aws_h1_connection *connection);
 

--- a/include/aws/http/private/strutil.h
+++ b/include/aws/http/private/strutil.h
@@ -67,9 +67,7 @@ bool aws_strutil_is_http_reason_phrase(struct aws_byte_cursor cursor);
 /**
  * Return whether this ASCII/UTF-8 sequence is a valid HTTP request-target.
  *
- * TODO: Actually check the complete grammar as defined in RFC7230 5.3 and
- * RFC3986. Currently this just checks whether the sequence is blatantly illegal
- * (ex: contains CR or LF)
+ * Note: rejects non-visible ASCII only, not the full RFC7230 5.3 / RFC3986 grammar. See the implementation.
  */
 AWS_HTTP_API
 bool aws_strutil_is_http_request_target(struct aws_byte_cursor cursor);

--- a/include/aws/http/private/strutil.h
+++ b/include/aws/http/private/strutil.h
@@ -67,7 +67,8 @@ bool aws_strutil_is_http_reason_phrase(struct aws_byte_cursor cursor);
 /**
  * Return whether this ASCII/UTF-8 sequence is a valid HTTP request-target.
  *
- * Note: rejects non-visible ASCII only, not the full RFC7230 5.3 / RFC3986 grammar. See the implementation.
+ * Only rejects non-visible ASCII, not the full RFC7230 5.3 / RFC3986 grammar. Tightening this would start
+ * rejecting request-targets we accept today, so it belongs in a minor release, not a patch.
  */
 AWS_HTTP_API
 bool aws_strutil_is_http_request_target(struct aws_byte_cursor cursor);

--- a/include/aws/http/websocket.h
+++ b/include/aws/http/websocket.h
@@ -12,8 +12,14 @@ AWS_PUSH_SANE_WARNING_LEVEL
 struct aws_http_header;
 struct aws_http_message;
 
-/* TODO: Document lifetime stuff */
-/* TODO: Document CLOSE frame behavior (when auto-sent during close, when auto-closed) */
+/**
+ * Lifetime: the websocket is ref-counted. on_connection_setup hands you one reference; release it with
+ * aws_websocket_release(). Releasing is not closing - call aws_websocket_close() to close.
+ *
+ * CLOSE frames: one is sent automatically during normal channel shutdown, unless shutdown asked to free scarce
+ * resources immediately or writing already stopped (which is the case once you sent your own CLOSE).
+ * Receiving a CLOSE does not close the connection - reading stops, but you must call aws_websocket_close().
+ */
 /* TODO: Accept payload as aws_input_stream */
 
 /**

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -124,7 +124,7 @@ enum aws_http_connection_manager_count_type {
  * READY - connections may be acquired and released.  When the external ref count for the manager
  * drops to zero, the manager moves to:
  *
- * TODO: Seems like connections can still be release while shutting down.
+ * Connections may still be released while SHUTTING_DOWN: vended_connection_count can only reach zero that way.
  * SHUTTING_DOWN - connections may no longer be acquired and released (how could they if the external
  * ref count was accurate?) but in case of user ref errors, we simply fail attempts to do so rather
  * than crash or underflow.  While in this state, we wait for a set of tracking counters to all fall to zero:

--- a/source/strutil.c
+++ b/source/strutil.c
@@ -205,8 +205,8 @@ bool aws_strutil_is_http_request_target(struct aws_byte_cursor cursor) {
         return false;
     }
 
-    /* TODO: Actually check the complete grammar as defined in RFC7230 5.3 and
-     * RFC3986. Currently this just checks whether the sequence is blatantly illegal */
+    /* Not the full RFC7230 5.3 / RFC3986 grammar on purpose: it would reject targets servers accept in practice.
+     * We only reject non-visible ASCII, which is what could split the request line. */
     size_t i = 0;
     do {
         const uint8_t c = cursor.ptr[i++];

--- a/source/strutil.c
+++ b/source/strutil.c
@@ -205,8 +205,9 @@ bool aws_strutil_is_http_request_target(struct aws_byte_cursor cursor) {
         return false;
     }
 
-    /* Not the full RFC7230 5.3 / RFC3986 grammar on purpose: it would reject targets servers accept in practice.
-     * We only reject non-visible ASCII, which is what could split the request line. */
+    /* Only reject non-visible ASCII, which is what could split the request line.
+     * Enforcing the full RFC7230 5.3 / RFC3986 grammar would reject request-targets callers send successfully
+     * today, so it is a behavior break for them, not a bug fix: it belongs in a minor release. */
     size_t i = 0;
     do {
         const uint8_t c = cursor.ptr[i++];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -499,9 +499,9 @@ add_test_case(h2_client_manual_window_management_user_send_conn_window_update_wi
 add_test_case(h2_client_manual_window_management_user_send_connection_window_update_overflow_capped)
 
 # Build these when we address window_update() differences in H1 vs H2
-# TODO add_test_case(h2_client_manual_updated_window_ignored_when_automatical_on)
-# TODO add_test_case(h2_client_manual_stream_updated_window_ignored_invalid_state)
-# TODO add_test_case(h2_client_manual_window_management_window_overflow) #we cannot ensure the increment_size is safe or not, let our peer detect the maximum exceed or not. But we can test the obviously overflows here.
+add_test_case(h2_client_manual_updated_window_ignored_when_automatical_on)
+add_test_case(h2_client_manual_stream_updated_window_ignored_invalid_state)
+# Window-update overflow is already covered by the *_overflow_capped cases above.
 add_test_case(h2_client_send_ping_successfully_receive_ack)
 add_test_case(h2_client_send_ping_no_ack_received)
 add_test_case(h2_client_conn_err_extraneous_ping_ack_received)

--- a/tests/test_h2_client.c
+++ b/tests/test_h2_client.c
@@ -3937,6 +3937,104 @@ TEST_CASE(h2_client_change_settings_failed_no_ack_received) {
     return AWS_OP_SUCCESS;
 }
 
+/* When manual window management is off (automatic window update is on), aws_http_stream_update_window() is not
+ * supported and must be ignored, rather than sending a second WINDOW_UPDATE on top of the automatic one. */
+TEST_CASE(h2_client_manual_updated_window_ignored_when_automatical_on) {
+    /* stream manual window management OFF, so window updates are automatic */
+    ASSERT_SUCCESS(s_manual_window_management_tester_init(
+        allocator, false /*conn*/, false /*stream*/, AWS_H2_INIT_WINDOW_SIZE, ctx));
+    ASSERT_SUCCESS(h2_fake_peer_send_connection_preface_default_settings(&s_tester.peer));
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+
+    struct aws_http_message *request = aws_http2_message_new_request(allocator);
+    ASSERT_NOT_NULL(request);
+    struct aws_http_header request_headers_src[] = {
+        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":scheme", "https"),
+        DEFINE_HEADER(":path", "/"),
+    };
+    aws_http_message_add_header_array(request, request_headers_src, AWS_ARRAY_SIZE(request_headers_src));
+
+    struct client_stream_tester stream_tester;
+    ASSERT_SUCCESS(s_stream_tester_init(&stream_tester, request));
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+
+    const uint32_t stream_id = aws_http_stream_get_id(stream_tester.stream);
+    struct aws_h2_stream *h2_stream = AWS_CONTAINER_OF(stream_tester.stream, struct aws_h2_stream, base);
+    const uint32_t window_before = h2_stream->thread_data.window_size_self;
+
+    /* Ask for a window increment. It must be ignored, since we are not in manual mode. */
+    aws_http_stream_update_window(stream_tester.stream, 1024);
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+
+    ASSERT_UINT_EQUALS(window_before, h2_stream->thread_data.window_size_self);
+
+    /* And no WINDOW_UPDATE frame was sent for this stream */
+    ASSERT_SUCCESS(h2_fake_peer_decode_messages_from_testing_channel(&s_tester.peer));
+    ASSERT_NULL(
+        h2_decode_tester_find_stream_frame(&s_tester.peer.decode, AWS_H2_FRAME_T_WINDOW_UPDATE, stream_id, 0, NULL));
+    ASSERT_TRUE(aws_http_connection_is_open(s_tester.connection));
+
+    aws_http_message_release(request);
+    client_stream_tester_clean_up(&stream_tester);
+    return s_tester_clean_up();
+}
+
+/* A window update requested on a stream that has not been activated yet (API state INIT) must not be sent, since the
+ * stream has no id on the wire yet. */
+TEST_CASE(h2_client_manual_stream_updated_window_ignored_invalid_state) {
+    ASSERT_SUCCESS(s_manual_window_management_tester_init(
+        allocator, false /*conn*/, true /*stream*/, AWS_H2_INIT_WINDOW_SIZE, ctx));
+    ASSERT_SUCCESS(h2_fake_peer_send_connection_preface_default_settings(&s_tester.peer));
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+
+    struct aws_http_message *request = aws_http2_message_new_request(allocator);
+    ASSERT_NOT_NULL(request);
+    struct aws_http_header request_headers_src[] = {
+        DEFINE_HEADER(":method", "GET"),
+        DEFINE_HEADER(":scheme", "https"),
+        DEFINE_HEADER(":path", "/"),
+    };
+    aws_http_message_add_header_array(request, request_headers_src, AWS_ARRAY_SIZE(request_headers_src));
+
+    /* Create the stream but deliberately do NOT activate it */
+    struct aws_http_make_request_options options = {
+        .self_size = sizeof(options),
+        .request = request,
+    };
+    struct aws_http_stream *stream = aws_http_connection_make_request(s_tester.connection, &options);
+    ASSERT_NOT_NULL(stream);
+
+    struct aws_h2_stream *h2_stream = AWS_CONTAINER_OF(stream, struct aws_h2_stream, base);
+    const uint32_t window_before = h2_stream->thread_data.window_size_self;
+
+    /* Request a window update while the stream is still in the INIT api state */
+    aws_http_stream_update_window(stream, 1024);
+    testing_channel_drain_queued_tasks(&s_tester.testing_channel);
+
+    /* Nothing was applied and no frame went out, and the connection is unharmed */
+    ASSERT_UINT_EQUALS(window_before, h2_stream->thread_data.window_size_self);
+    ASSERT_SUCCESS(h2_fake_peer_decode_messages_from_testing_channel(&s_tester.peer));
+
+    /* No *stream-level* WINDOW_UPDATE was sent. Connection-level ones (stream id 0) are normal traffic and expected. */
+    size_t search_idx = 0;
+    while (true) {
+        size_t found_idx = 0;
+        struct h2_decoded_frame *frame =
+            h2_decode_tester_find_frame(&s_tester.peer.decode, AWS_H2_FRAME_T_WINDOW_UPDATE, search_idx, &found_idx);
+        if (frame == NULL) {
+            break;
+        }
+        ASSERT_UINT_EQUALS(0, frame->stream_id);
+        search_idx = found_idx + 1;
+    }
+    ASSERT_TRUE(aws_http_connection_is_open(s_tester.connection));
+
+    aws_http_stream_release(stream);
+    aws_http_message_release(request);
+    return s_tester_clean_up();
+}
+
 /* Test manual window management for stream successfully disabled the automatically window update */
 TEST_CASE(h2_client_manual_window_management_disabled_auto_window_update) {
     size_t window_size = 10;

--- a/tests/test_strutil.c
+++ b/tests/test_strutil.c
@@ -241,9 +241,25 @@ static int s_strutil_is_http_request_target(struct aws_allocator *allocator, voi
     /* OK asterisk-form */
     ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("*")));
 
-    /* TODO: Actually check the complete grammar as defined in RFC7230 5.3 and
-     * RFC3986. Currently this just checks whether the sequence is blatantly illegal
-     * (ex: contains CR or LF) */
+    /* Every other non-visible ASCII character is rejected too, since any of them could break request framing.
+     * Use an explicit length so that the NUL case is actually tested. */
+    for (uint32_t c = 0; c <= ' '; ++c) {
+        uint8_t str[] = {'/', 'p', 'a', 't', 'h', (uint8_t)c};
+        ASSERT_FALSE(aws_strutil_is_http_request_target(aws_byte_cursor_from_array(str, sizeof(str))));
+    }
+
+    /* We deliberately do NOT enforce the full RFC7230 5.3 / RFC3986 grammar, so a request-target containing
+     * characters that are technically illegal but accepted by servers in practice is still allowed through.
+     * These cases pin that intent: they are not accidentally-passing, they are what we promise. */
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path?q={braces}")));
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path?q=a|b")));
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path?q=\"quoted\"")));
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path^caret")));
+    /* Malformed percent-encoding is not diagnosed here either */
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path%zz")));
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path%")));
+    /* Nor is a fragment, which RFC7230 5.3 says is not part of a request-target */
+    ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path#fragment")));
 
     return 0;
 }

--- a/tests/test_strutil.c
+++ b/tests/test_strutil.c
@@ -248,9 +248,8 @@ static int s_strutil_is_http_request_target(struct aws_allocator *allocator, voi
         ASSERT_FALSE(aws_strutil_is_http_request_target(aws_byte_cursor_from_array(str, sizeof(str))));
     }
 
-    /* We deliberately do NOT enforce the full RFC7230 5.3 / RFC3986 grammar, so a request-target containing
-     * characters that are technically illegal but accepted by servers in practice is still allowed through.
-     * These cases pin that intent: they are not accidentally-passing, they are what we promise. */
+    /* The full RFC7230 5.3 / RFC3986 grammar is not enforced, so these technically-illegal targets pass.
+     * Pinned here because tightening the check would break callers already sending them. */
     ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path?q={braces}")));
     ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path?q=a|b")));
     ASSERT_TRUE(aws_strutil_is_http_request_target(aws_byte_cursor_from_c_str("/path?q=\"quoted\"")));


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Answers TODOs that asked for documentation, and implements two tests that were registered as TODO placeholders.

Documented: websocket ref-count lifetime and CLOSE-frame behavior; why the request-target check deliberately stays looser than RFC7230 5.3 (tightening it would reject targets callers send today, so it needs a minor release); and that releasing a connection while the manager is shutting down is required, not a bug.

Implemented: the two commented-out `h2_client_manual_*_window` cases, covering window updates that must be ignored when automatic management is on or the stream is not yet activated. The third was already covered by the existing overflow cases.

No behavior change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
