### PR TITLE
Make h2benchmark configurable

### DIFF
--- a/bin/h2benchmark/CMakeLists.txt
+++ b/bin/h2benchmark/CMakeLists.txt
@@ -24,11 +24,11 @@ install(TARGETS ${PROJECT_NAME}
 # Option-parsing tests. These all finish inside s_parse_options() before any network
 # setup, so they need no server. --help exits 0; every rejected value exits 1.
 if (BUILD_TESTING)
-    add_test(NAME h2benchmark_help COMMAND ${PROJECT_NAME} --help)
+    add_test(h2benchmark_help ${PROJECT_NAME} --help)
     set_tests_properties(h2benchmark_help PROPERTIES PASS_REGULAR_EXPRESSION "usage: h2benchmark")
 
     # 0 is documented as a valid log level ("none") and is the default, so it must be accepted.
-    add_test(NAME h2benchmark_log_level_zero COMMAND ${PROJECT_NAME} --log-level 0 --help)
+    add_test(h2benchmark_log_level_zero ${PROJECT_NAME} --log-level 0 --help)
     set_tests_properties(h2benchmark_log_level_zero PROPERTIES PASS_REGULAR_EXPRESSION "usage: h2benchmark")
 
     foreach(case
@@ -42,7 +42,7 @@ if (BUILD_TESTING)
         set(case_args "${case}")
         list(GET case_args 0 case_name)
         list(REMOVE_AT case_args 0)
-        add_test(NAME h2benchmark_reject_${case_name} COMMAND ${PROJECT_NAME} ${case_args})
+        add_test(h2benchmark_reject_${case_name} ${PROJECT_NAME} ${case_args})
         set_tests_properties(h2benchmark_reject_${case_name} PROPERTIES WILL_FAIL TRUE)
     endforeach()
 endif()

--- a/bin/h2benchmark/CMakeLists.txt
+++ b/bin/h2benchmark/CMakeLists.txt
@@ -20,3 +20,29 @@ install(TARGETS ${PROJECT_NAME}
         RUNTIME
         DESTINATION ${CMAKE_INSTALL_BINDIR}
         COMPONENT Runtime)
+
+# Option-parsing tests. These all finish inside s_parse_options() before any network
+# setup, so they need no server. --help exits 0; every rejected value exits 1.
+if (BUILD_TESTING)
+    add_test(NAME h2benchmark_help COMMAND ${PROJECT_NAME} --help)
+    set_tests_properties(h2benchmark_help PROPERTIES PASS_REGULAR_EXPRESSION "usage: h2benchmark")
+
+    # 0 is documented as a valid log level ("none") and is the default, so it must be accepted.
+    add_test(NAME h2benchmark_log_level_zero COMMAND ${PROJECT_NAME} --log-level 0 --help)
+    set_tests_properties(h2benchmark_log_level_zero PROPERTIES PASS_REGULAR_EXPRESSION "usage: h2benchmark")
+
+    foreach(case
+            "rate_secs_text;--rate-secs;notanumber"
+            "rate_secs_zero;--rate-secs;0"
+            "max_connections_negative;--max-connections;-1"
+            "streams_trailing_garbage;--streams-per-connection;12abc"
+            "rate_threshold_text;--rate-threshold;xyz"
+            "log_level_out_of_range;--log-level;99"
+            "unknown_option;--no-such-option")
+        set(case_args "${case}")
+        list(GET case_args 0 case_name)
+        list(REMOVE_AT case_args 0)
+        add_test(NAME h2benchmark_reject_${case_name} COMMAND ${PROJECT_NAME} ${case_args})
+        set_tests_properties(h2benchmark_reject_${case_name} PROPERTIES WILL_FAIL TRUE)
+    endforeach()
+endif()

--- a/bin/h2benchmark/README.md
+++ b/bin/h2benchmark/README.md
@@ -7,4 +7,22 @@ It collects how many API calls finish per second. Basically how many request can
 The program connects to the local host that can be found [here](../../tests/mock_server).
 
 To run the benchmark, build the h2benchmark with aws-c-http as dependency.
-TODO: Currently the configs are all hardcoded.
+
+## Configuration
+
+Run `h2benchmark --help` for the full list. The defaults match what CI uses, so no arguments are needed for a
+standard run. The available options are:
+
+| Option | Description | Default |
+| --- | --- | --- |
+| `-u, --uri` | URI to benchmark against | `http://localhost:3280/` |
+| `-r, --rate-secs` | Seconds per measurement interval | 30 |
+| `-s, --streams-per-connection` | Max concurrent streams per connection | 20 |
+| `-c, --max-connections` | Max connections | 8 |
+| `-n, --num-loops` | Number of intervals to measure | 5 |
+| `-t, --rate-threshold` | Fail if streams/sec averages below this | 4000 |
+| `-l, --log-level` | 0=none 1=fatal 2=error 3=warn 4=info 5=debug 6=trace | 0 |
+| `-d, --direct-connection` | Use a single connection instead of the stream manager | off |
+
+The process exits non-zero if the average streams/sec falls below `--rate-threshold`, which is what makes it usable
+as a regression check. On a slow machine you may need to lower that threshold.

--- a/bin/h2benchmark/README.md
+++ b/bin/h2benchmark/README.md
@@ -10,8 +10,7 @@ To run the benchmark, build the h2benchmark with aws-c-http as dependency.
 
 ## Configuration
 
-Run `h2benchmark --help` for the full list. The defaults match what CI uses, so no arguments are needed for a
-standard run. The available options are:
+Run `h2benchmark --help` for the full list. The defaults match what CI uses, so no arguments are needed for a standard run. The available options are:
 
 | Option | Description | Default |
 | --- | --- | --- |
@@ -24,5 +23,4 @@ standard run. The available options are:
 | `-l, --log-level` | 0=none 1=fatal 2=error 3=warn 4=info 5=debug 6=trace | 0 |
 | `-d, --direct-connection` | Use a single connection instead of the stream manager | off |
 
-The process exits non-zero if the average streams/sec falls below `--rate-threshold`, which is what makes it usable
-as a regression check. On a slow machine you may need to lower that threshold.
+The process exits non-zero if the average streams/sec falls below `--rate-threshold`, which is what makes it usable as a regression check. On a slow machine you may need to lower that threshold.

--- a/bin/h2benchmark/main.c
+++ b/bin/h2benchmark/main.c
@@ -25,6 +25,8 @@
 #include <aws/io/uri.h>
 
 #include <inttypes.h>
+#include <limits.h>
+#include <stdlib.h>
 
 #ifdef _MSC_VER
 #    pragma warning(disable : 4204) /* Declared initializers */
@@ -37,19 +39,30 @@
         .value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(VALUE),                                                         \
     }
 
-/* TODO: Make those configurable from cmd line */
-const struct aws_byte_cursor uri_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("http://localhost:3280/");
-const int rate_secs = 30; /* Time interval to collect data */
-const int streams_per_connection = 20;
-const int max_connections = 8;
-const int num_data_to_collect = 5; /* The number of data to collect */
-const enum aws_log_level log_level = AWS_LOG_LEVEL_NONE;
-const bool direct_connection = false; /* If true, will create one connection and make requests from that connection.
-                                       * If false, will use stream manager to acquire streams */
+/* Defaults for the settings below. Each can be overridden from the command line, see s_parse_options(). */
+#define DEFAULT_URI "http://localhost:3280/"
+#define DEFAULT_RATE_SECS 30
+#define DEFAULT_STREAMS_PER_CONNECTION 20
+#define DEFAULT_MAX_CONNECTIONS 8
+#define DEFAULT_NUM_DATA_TO_COLLECT 5
+#define DEFAULT_DIRECT_CONNECTION false
+/**
+ * From the previous tests, all platforms seem to sustain more than 4000 streams/sec.
+ * It is not platform specific, so on a slow machine you may need to lower it with --rate-threshold.
+ */
+#define DEFAULT_RATE_THRESHOLD 4000
 
-const double rate_threshold =
-    4000; /* From the previous tests. All platforms seem to be larger than 4000, but it could various. TODO: Maybe
-             gather the number of previous test run, and be platform specific. */
+static struct aws_byte_cursor uri_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(DEFAULT_URI);
+static int rate_secs = DEFAULT_RATE_SECS; /* Time interval to collect data */
+static int streams_per_connection = DEFAULT_STREAMS_PER_CONNECTION;
+static int max_connections = DEFAULT_MAX_CONNECTIONS;
+static int num_data_to_collect = DEFAULT_NUM_DATA_TO_COLLECT; /* The number of data to collect */
+static enum aws_log_level log_level = AWS_LOG_LEVEL_NONE;
+static bool direct_connection =
+    DEFAULT_DIRECT_CONNECTION; /* If true, will create one connection and make requests from that connection.
+                                * If false, will use stream manager to acquire streams */
+
+static double rate_threshold = DEFAULT_RATE_THRESHOLD;
 
 struct aws_http_benchmark_helper {
     struct aws_task task;
@@ -97,7 +110,8 @@ static void s_collect_data_task(struct aws_task *task, void *arg, enum aws_task_
     /* collect data */
     size_t stream_completed = aws_atomic_exchange_int(&app_ctx->streams_completed, 0);
 
-    /* TODO: maybe collect the data somewhere instead of just printing it out. */
+    /* Results are printed and averaged in-process; this is a pass/fail benchmark run from CI, so there is no
+     * store to report them to. */
     double rate = (double)stream_completed / rate_secs;
     helper->results[helper->num_collected] = rate;
     ++helper->num_collected;
@@ -344,9 +358,122 @@ static void s_run_benchmark(struct benchmark_ctx *app_ctx) {
     aws_http_message_release(request);
 }
 
+/************************* Command line options ************************************/
+
+static const struct aws_cli_option s_long_options[] = {
+    {"uri", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'u'},
+    {"rate-secs", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'r'},
+    {"streams-per-connection", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 's'},
+    {"max-connections", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'c'},
+    {"num-loops", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'n'},
+    {"rate-threshold", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 't'},
+    {"log-level", AWS_CLI_OPTIONS_REQUIRED_ARGUMENT, NULL, 'l'},
+    {"direct-connection", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'd'},
+    {"help", AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 'h'},
+    {NULL, AWS_CLI_OPTIONS_NO_ARGUMENT, NULL, 0},
+};
+
+static void s_print_usage(FILE *out) {
+    fprintf(
+        out,
+        "usage: h2benchmark [options]\n"
+        "\n"
+        "  -u, --uri URI                     URI to benchmark against (default: %s)\n"
+        "  -r, --rate-secs N                 seconds per measurement interval (default: %d)\n"
+        "  -s, --streams-per-connection N    max concurrent streams per connection (default: %d)\n"
+        "  -c, --max-connections N           max connections (default: %d)\n"
+        "  -n, --num-loops N                 number of intervals to measure (default: %d)\n"
+        "  -t, --rate-threshold F            fail if streams/sec averages below this (default: %d)\n"
+        "  -l, --log-level N                 0=none 1=fatal 2=error 3=warn 4=info 5=debug 6=trace (default: 0)\n"
+        "  -d, --direct-connection           use a single connection instead of the stream manager\n"
+        "  -h, --help                        show this message\n",
+        DEFAULT_URI,
+        DEFAULT_RATE_SECS,
+        DEFAULT_STREAMS_PER_CONNECTION,
+        DEFAULT_MAX_CONNECTIONS,
+        DEFAULT_NUM_DATA_TO_COLLECT,
+        DEFAULT_RATE_THRESHOLD);
+}
+
+/* Parse a non-negative integer option value, exiting on anything invalid. */
+static int s_parse_non_negative_int(const char *name, const char *value) {
+    char *end = NULL;
+    long parsed = strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
+        fprintf(stderr, "Invalid value for %s: '%s', expected a non-negative integer\n", name, value);
+        exit(1);
+    }
+    return (int)parsed;
+}
+
+/* Parse a positive integer option value, exiting on anything invalid. */
+static int s_parse_positive_int(const char *name, const char *value) {
+    char *end = NULL;
+    long parsed = strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed <= 0 || parsed > INT_MAX) {
+        fprintf(stderr, "Invalid value for %s: '%s', expected a positive integer\n", name, value);
+        exit(1);
+    }
+    return (int)parsed;
+}
+
+static void s_parse_options(int argc, char **argv) {
+    while (true) {
+        int option_index = 0;
+        int c = aws_cli_getopt_long(argc, argv, "u:r:s:c:n:t:l:dh", s_long_options, &option_index);
+        if (c == -1) {
+            break;
+        }
+
+        switch (c) {
+            case 'u':
+                uri_cursor = aws_byte_cursor_from_c_str(aws_cli_optarg);
+                break;
+            case 'r':
+                rate_secs = s_parse_positive_int("--rate-secs", aws_cli_optarg);
+                break;
+            case 's':
+                streams_per_connection = s_parse_positive_int("--streams-per-connection", aws_cli_optarg);
+                break;
+            case 'c':
+                max_connections = s_parse_positive_int("--max-connections", aws_cli_optarg);
+                break;
+            case 'n':
+                num_data_to_collect = s_parse_positive_int("--num-loops", aws_cli_optarg);
+                break;
+            case 't': {
+                char *end = NULL;
+                rate_threshold = strtod(aws_cli_optarg, &end);
+                if (end == aws_cli_optarg || *end != '\0' || rate_threshold < 0) {
+                    fprintf(stderr, "Invalid value for --rate-threshold: '%s'\n", aws_cli_optarg);
+                    exit(1);
+                }
+                break;
+            }
+            case 'l': {
+                int level = s_parse_non_negative_int("--log-level", aws_cli_optarg);
+                if (level > AWS_LOG_LEVEL_TRACE) {
+                    fprintf(stderr, "Invalid --log-level: %d, max is %d\n", level, AWS_LOG_LEVEL_TRACE);
+                    exit(1);
+                }
+                log_level = (enum aws_log_level)level;
+                break;
+            }
+            case 'd':
+                direct_connection = true;
+                break;
+            case 'h':
+                s_print_usage(stdout);
+                exit(0);
+            default:
+                s_print_usage(stderr);
+                exit(1);
+        }
+    }
+}
+
 int main(int argc, char **argv) {
-    (void)argc;
-    (void)argv;
+    s_parse_options(argc, argv);
 
     struct aws_allocator *allocator = aws_default_allocator();
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Makes the h2benchmark tool configurable instead of requiring a recompile to change anything. Nine hardcoded constants become command-line options with both short and long forms, validated on parse, with defaults shared between the code and `--help` so they cannot drift.

Adds nine CTest cases covering the argument surface. They complete during parsing, so no server is needed. Tool only; nothing here ships in the library.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
